### PR TITLE
Additional config support for status monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### 🎁 New Features
 
-* Added a new `xhEnableImpersonation` config for enabling or disabling impersonation app-wide.
+* Added a new `xhEnableImpersonation` config for enabling or disabling impersonation app-wide. Note
+  that this config will be defaulted to false if not yet defined - set to true after upgrade to
+  continue supporting impersonation for your application.
+* The `xhMonitorConfig` config supports two additional properties - `monitorTimeoutSecs` to control
+  the max runtime for any individual monitor check and `runInLocalDevMode` to enable scheduled
+  monitor runs during local development.
 
 ### ⚙️ Technical
 
@@ -13,6 +18,8 @@
   ([#95](https://github.com/xh/hoist-core/issues/95))
 * GORM validation exceptions are now handled by `BaseController` rather than `RestController`, so
   all endpoints will be handled consistently. ([#68](https://github.com/xh/hoist-core/issues/68))
+
+[Commit Log](https://github.com/xh/hoist-core/compare/v6.3.1...develop)
 
 ## 6.3.1 - 2019-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@
 * Added a new `xhEnableImpersonation` config for enabling or disabling impersonation app-wide. Note
   that this config will be defaulted to false if not yet defined - set to true after upgrade to
   continue supporting impersonation for your application.
-* The `xhMonitorConfig` config supports two additional properties - `monitorTimeoutSecs` to control
-  the max runtime for any individual monitor check and `runInLocalDevMode` to enable scheduled
-  monitor runs during local development.
+* The `xhMonitorConfig` config supports a new property `monitorTimeoutSecs` to control the max
+  runtime for any individual monitor check.
 
 ### ⚙️ Technical
 

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -146,7 +146,6 @@ class BootStrap {
                     monitorStartupDelayMins: 1,
                     monitorRepeatNotifyMins: 60,
                     monitorTimeoutSecs: 15,
-                    runInLocalDevMode: false,
                     writeToMonitorLog: true
                 ],
                 groupName: 'xh.io',

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -145,6 +145,8 @@ class BootStrap {
                     warnNotifyThreshold: 5,
                     monitorStartupDelayMins: 1,
                     monitorRepeatNotifyMins: 60,
+                    monitorTimeoutSecs: 15,
+                    runInLocalDevMode: false,
                     writeToMonitorLog: true
                 ],
                 groupName: 'xh.io',

--- a/grails-app/services/io/xh/hoist/monitor/MonitoringEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitoringEmailService.groovy
@@ -11,6 +11,10 @@ import io.xh.hoist.util.Utils
 
 import static io.xh.hoist.monitor.MonitorStatus.WARN
 
+/**
+ * Listens for status monitor change events from MonitoringService and emails status updates to
+ * a configurable list of recipients.
+ */
 class MonitoringEmailService extends BaseService {
 
     def emailService
@@ -26,7 +30,7 @@ class MonitoringEmailService extends BaseService {
     //------------------------
     private void emailReport(MonitorStatusReport report) {
         def to = emailService.parseMailConfig('xhMonitorEmailRecipients')
-        if (to && to != 'none') {
+        if (to) {
             emailService.sendEmail(
                 to: to,
                 subject: report.title,


### PR DESCRIPTION
+ Add `monitorTimeoutSecs` to control max runtime of each monitor check.
+ Add `runInLocalDevMode` to enabled scheduled monitor runs during local development.
+ Tweaks to timeout/exception messages.
+ Fixes #103