### PR TITLE
Fix bug in ValidationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 7.0-SNAPSHOT - under development
 
-* TBD!
+### 🐞 Bug Fixes
+
+* Fixed an issue where GORM validation exceptions would trigger MethodNotFoundException
 
 [Commit Log](https://github.com/xh/hoist-core/compare/v6.4.0...develop)
 

--- a/src/main/groovy/io/xh/hoist/exception/ValidationException.groovy
+++ b/src/main/groovy/io/xh/hoist/exception/ValidationException.groovy
@@ -7,6 +7,7 @@
 
 package io.xh.hoist.exception
 
+import groovy.transform.CompileStatic
 import io.xh.hoist.util.Utils
 
 /**
@@ -17,7 +18,7 @@ class ValidationException extends RuntimeException implements RoutineException {
         super(parseMessage(ex), ex)
     }
 
-    private String parseMessage(grails.validation.ValidationException ex) {
+    private static String parseMessage(grails.validation.ValidationException ex) {
         def msgSrc = Utils.appContext.messageSource
         return ex.errors.allErrors
                 .collect {msgSrc.getMessage(it, Locale.US)}


### PR DESCRIPTION
Java seems to prohibit calling a non-static method as a parameter to super() in a constructor, e.g. super(toString()). I don't know how I committed such a broken version, but it should be fixed now.