### PR TITLE
Config canonical form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 7.0-SNAPSHOT - under development
 
+### 🎁 New Features
+
+* Configs formatted as JSON will now be converted to a canonical form before storing in the database, ensuring 
+  consistent formatting and strict adherence to the JSON spec.
+
 ### 🐞 Bug Fixes
 
 * Fixed an issue where GORM validation exceptions would trigger MethodNotFoundException

--- a/grails-app/controllers/io/xh/hoist/admin/ConfigAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/ConfigAdminController.groovy
@@ -7,12 +7,15 @@
 
 package io.xh.hoist.admin
 
+import groovy.util.logging.Slf4j
 import io.xh.hoist.config.AppConfig
 import io.xh.hoist.RestController
 import io.xh.hoist.security.Access
 import org.grails.web.json.JSONObject
+import io.xh.hoist.json.JSON
 
 @Access(['HOIST_ADMIN'])
+@Slf4j
 class ConfigAdminController extends RestController {
 
     static restTarget = AppConfig
@@ -26,7 +29,10 @@ class ConfigAdminController extends RestController {
     }
 
     protected void preprocessSubmit(JSONObject submit) {
+        def valueType = AppConfig.get(submit.id)?.valueType ?: submit.valueType
+        if (valueType.equals('json')) {
+            submit.value = JSON.parse(submit.value).toString(2);
+        }
         submit.lastUpdatedBy = username
     }
-
 }

--- a/grails-app/controllers/io/xh/hoist/admin/ConfigAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/ConfigAdminController.groovy
@@ -7,7 +7,6 @@
 
 package io.xh.hoist.admin
 
-import groovy.util.logging.Slf4j
 import io.xh.hoist.config.AppConfig
 import io.xh.hoist.RestController
 import io.xh.hoist.security.Access
@@ -15,7 +14,6 @@ import org.grails.web.json.JSONObject
 import io.xh.hoist.json.JSON
 
 @Access(['HOIST_ADMIN'])
-@Slf4j
 class ConfigAdminController extends RestController {
 
     static restTarget = AppConfig


### PR DESCRIPTION
This change causes all JSON configs to be standardized before saving in the DB.

I am not sure this is the fix we want, but it's worth discussing.