### PR TITLE
Strict json validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 7.0-SNAPSHOT - under development
 
+### ⚙️ Technical
+
+* `JsonSlurper` is now used for JSON validation, which should be stricter than using `JSON.parse`
+
 ### 🐞 Bug Fixes
 
 * Fixed an issue where GORM validation exceptions would trigger MethodNotFoundException

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -8,6 +8,7 @@
 package io.xh.hoist.util
 
 import grails.util.Holders
+import groovy.json.JsonParserType
 import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 import io.xh.hoist.AppEnvironment
@@ -29,7 +30,7 @@ import org.springframework.context.ApplicationContext
 class Utils {
 
     static Properties buildInfo = readBuildInfo()
-    static JsonSlurper validator = new JsonSlurper();
+    static JsonSlurper validator = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY)
 
     /**
      * Internal short name of the application - lowercase, no spaces.

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -8,6 +8,8 @@
 package io.xh.hoist.util
 
 import grails.util.Holders
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
 import io.xh.hoist.AppEnvironment
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.ConfigService
@@ -23,9 +25,11 @@ import org.grails.web.json.JSONObject
 import org.springframework.context.ApplicationContext
 
 
+@Slf4j
 class Utils {
 
     static Properties buildInfo = readBuildInfo()
+    static JsonSlurper validator = new JsonSlurper();
 
     /**
      * Internal short name of the application - lowercase, no spaces.
@@ -106,12 +110,11 @@ class Utils {
         TrackLog.withNewSession(c) // Yes, a bizarre dependency on an arbitrary domain object
     }
 
-
     static boolean isJSON(String val) {
         try {
-            if (val != null) JSON.parse(val)
+            if (val != null) validator.parse(new StringReader(val))
             return true
-        } catch (ConverterException ignored) {
+        } catch (Exception ignored) {
             return false
         }
     }

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -10,23 +10,18 @@ package io.xh.hoist.util
 import grails.util.Holders
 import groovy.json.JsonParserType
 import groovy.json.JsonSlurper
-import groovy.util.logging.Slf4j
 import io.xh.hoist.AppEnvironment
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.ConfigService
-import io.xh.hoist.json.JSON
 import io.xh.hoist.pref.PrefService
 import io.xh.hoist.track.TrackLog
 import io.xh.hoist.user.BaseRoleService
 import io.xh.hoist.user.BaseUserService
 import io.xh.hoist.websocket.WebSocketService
-import org.grails.web.converters.exceptions.ConverterException
 import org.grails.web.json.JSONArray
 import org.grails.web.json.JSONObject
 import org.springframework.context.ApplicationContext
 
-
-@Slf4j
 class Utils {
 
     static Properties buildInfo = readBuildInfo()

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -112,7 +112,7 @@ class Utils {
 
     static boolean isJSON(String val) {
         try {
-            if (val != null) validator.parse(new StringReader(val))
+            if (val != null) validator.parseText(val)
             return true
         } catch (Exception ignored) {
             return false


### PR DESCRIPTION
This uses JsonSlurper, which is by default stricter than JSON.parse.

It does not strictly follow the JSON spec, however. I have found that it deviates from the spec by allowing trailing commas, and possibly is lax in other ways.

EDIT: Performance may also be improved, but I haven't benchmarked it and I doubt we care.