### PR TITLE
Reversed lines reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Commit Log](https://github.com/xh/hoist-core/compare/v6.4.1...develop)
 
+### ⚙️ Technical
+
+* Made `LogViewerAdminController` use a streaming access file, reducing memory usage on large files. 
+  [#115](https://github.com/xh/hoist-core/issues/115)
 
 ## 6.4.1 - 2020-02-29
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     compile 'org.jasypt:jasypt:1.9.2'
     compile "io.reactivex.rxjava2:rxjava:2.1.3"
     compile "com.grack:nanojson:1.4"
+
+    compile 'commons-io:commons-io:2.6'
 }
 
 bootRun {

--- a/grails-app/controllers/io/xh/hoist/admin/LogViewerAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/LogViewerAdminController.groovy
@@ -16,7 +16,7 @@ import io.xh.hoist.security.Access
 class LogViewerAdminController extends BaseController {
 
     def logArchiveService,
-            logReaderService
+        logReaderService
 
     def listFiles() {
         def baseDir = new File(LogUtils.logRootPath),
@@ -32,24 +32,13 @@ class LogViewerAdminController extends BaseController {
         renderJSON(success:true, files:ret)
     }
 
-    /**
-     * Fetch the (selected) contents of a log file for viewing in the admin console.
-     * @param filename - (required) path to file from log root dir
-     * @param startLine - (optional) line number of file to start at; if null or zero or negative, will return tail of file
-     * @param maxLines - (optional) number of lines to return
-     * @param pattern - (optional) only lines matching pattern will be returned
-     * @return - JSON with content property containing multi-dim array of [lineNumber,text] for lines in file
-     */
     def getFile(String filename, Integer startLine, Integer maxLines, String pattern) {
         // Catch any exceptions and render clean failure - the admin client auto-polls for log file
         // updates, and we don't want to spam the logs with a repeated stacktrace.
         try {
-            def file = new File(LogUtils.logRootPath, filename),
-                content = logReaderService.readFile(file, startLine, maxLines, pattern)
-
-            renderJSON(success: file.exists(), filename: filename, content: content)
+            def content = logReaderService.readFile(filename, startLine, maxLines, pattern)
+            renderJSON(success: true, filename: filename, content: content)
         } catch (Exception e) {
-            throw(e)
             renderJSON(success: false, filename: filename, content: [], exception: e.message)
         }
     }

--- a/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
@@ -1,0 +1,112 @@
+package io.xh.hoist.log
+
+import io.xh.hoist.BaseService
+import org.apache.commons.io.input.ReversedLinesFileReader
+
+class LogReaderService extends BaseService {
+
+    def records = [:]
+
+    /**
+     * Fetch the (selected) contents of a log file for viewing in the admin console.
+     * @param file - (required) File to be read
+     * @param startLine - (optional) line number of file to start at; if null or zero or negative, will return tail of file
+     * @param maxLines - (optional) number of lines to return
+     * @param pattern - (optional) only lines matching pattern will be returned
+     * @return - Multi-dimensional array of [linenumber, text] for the requested lines
+     */
+    synchronized readFile(File file, Integer startLine, Integer maxLines, String pattern, Integer maxSearch = 1000000) {
+        def tail = !startLine || startLine < 0,
+            ret = [],
+            lineNumber,
+            lineIncrement,
+            reader,
+            numSearched = 0
+
+        if(!file.exists()) {
+            records.remove(file.getAbsolutePath())
+            throw new FileNotFoundException()
+        }
+
+        try {
+            if (tail) {
+                lineNumber = getLength(file)
+                reader = new ReversedLinesFileReader(file)
+                lineIncrement = -1
+            } else {
+                lineNumber = startLine
+                reader = new BufferedReader(new FileReader(file))
+                (1..<lineNumber).each { reader.readLine() }
+                lineIncrement = 1
+            }
+
+            for (def line = reader.readLine();
+                 line != null && ret.size() < maxLines;
+                 line = reader.readLine()) {
+                numSearched++
+                if(numSearched > maxSearch) {
+                    ret << [lineNumber, 'Search aborted due to ']
+                }
+                if (!pattern || line.toLowerCase() =~ pattern.toLowerCase()) {
+                    ret << [lineNumber, line]
+                    lineNumber += lineIncrement
+                }
+            }
+
+            return ret
+        } finally {
+            if(reader) {
+                reader.close()
+            }
+        }
+    }
+
+    long getLength(File file) {
+        def path = file.getAbsolutePath()
+        if(!records.containsKey(path)) {
+            records[path] = new LengthRecord(file)
+        }
+        return records[path].getLength()
+    }
+
+    @Override
+    void destroy() {
+        records.values().each {it.destroy()}
+    }
+
+    class LengthRecord {
+        File file
+        BufferedReader reader
+        long length = 0
+        long bytes = 0;
+
+        LengthRecord(File file) {
+            this.file = file
+            reader = new BufferedReader(new FileReader(file))
+        }
+
+        long getLength() {
+            update()
+            return length
+        }
+
+        long update() {
+            if(file.size() < bytes) {
+                log.info('Log file was deleted or truncated, re-reading...')
+                length = 0;
+                bytes = 0
+                reader.close()
+                reader = new BufferedReader(new FileReader(file))
+            }
+
+            bytes = file.size()
+
+            while(reader.readLine() != null) length++
+            return length
+        }
+
+        void destroy() {
+            reader.close()
+        }
+    }
+}

--- a/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
@@ -41,12 +41,9 @@ class LogReaderService extends BaseService {
             }
 
             for (def line = reader.readLine();
-                 line != null && ret.size() < maxLines;
+                 line != null && ret.size() < maxLines && numSearched < maxSearch;
                  line = reader.readLine()) {
                 numSearched++
-                if(numSearched > maxSearch) {
-                    ret << [lineNumber, 'Search aborted due to ']
-                }
                 if (!pattern || line.toLowerCase() =~ pattern.toLowerCase()) {
                     ret << [lineNumber, line]
                     lineNumber += lineIncrement


### PR DESCRIPTION
This change solves the problem with excessive memory usage. I have verified that it works correctly on a 10 GiB log file.

I still do not like the fact that we read the entire file to get line counts before we can start reading from the end. On my 10 GiB sample it took 25 seconds to load the log file in the browser, and one CPU core was pinned to 100% for all 25 seconds. However, this is still an improvement over the previous version, which would have died from an OutOfMemoryError.