### PR TITLE
Disabled logReaderService endpoint and added default xhEnableLogViewer config to Bootstrap

### DIFF
--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -121,6 +121,13 @@ class BootStrap {
                 groupName: 'xh.io',
                 note: 'True to allow Hoist Admins to impersonate other users.'
             ],
+            xhEnableLogViewer: [
+                valueType: 'bool',
+                defaultValue: true,
+                clientVisible: true,
+                groupName: 'xh.io',
+                note: 'True to enable log viewer.'
+            ],
             xhIdleTimeoutMins: [
                 valueType: 'int',
                 defaultValue: -1,

--- a/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
@@ -22,7 +22,7 @@ class LogReaderService extends BaseService {
      */
     List readFile(String filename, Integer startLine, Integer maxLines, String pattern) {
         if (!configService.getBool('xhEnableLogViewer')) {
-            throw new RuntimeException('Log Viewer disabled. See xhEnableLogViewer config.')
+            throw new RuntimeException("Log Viewer disabled. See 'xhEnableLogViewer' config.")
         }
 
         return (List) withDebug('Reading log file ' + filename + '|' + startLine + '|' + maxLines + '|' + pattern) {

--- a/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogReaderService.groovy
@@ -21,6 +21,10 @@ class LogReaderService extends BaseService {
      * @return - List of elements of the form [linenumber, text] for the requested lines
      */
     List readFile(String filename, Integer startLine, Integer maxLines, String pattern) {
+        if (!configService.getBool('xhEnableLogViewer')) {
+            throw new RuntimeException('Log Viewer disabled. See xhEnableLogViewer config.')
+        }
+
         return (List) withDebug('Reading log file ' + filename + '|' + startLine + '|' + maxLines + '|' + pattern) {
             doRead(filename, startLine, maxLines, pattern)
         }


### PR DESCRIPTION
This PR addresses issue https://github.com/xh/hoist-core/issues/124
- Throw runtimeException on logReaderService readFile when xhEnableLogViewer config is false
- Added xhEnableLogViewer config to Bootstrap (default to true)
