### PR TITLE
Add config to adjust when excel export switches to streaming API.

### DIFF
--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -128,12 +128,15 @@ class BootStrap {
                 groupName: 'xh.io',
                 note: 'True to enable the log viewer included with the Hoist Admin console as well as the associated server-side endpoints.'
             ],
-            xhExportTableCellThreshold: [
-                valueType: 'int',
-                defaultValue: 100000,
+            xhExportConfig: [
+                valueType: 'json',
+                defaultValue: [
+                    streamingCellThreshold: 100000,
+                    toastCellThreshold: 3000
+                ],
                 clientVisible: true,
                 groupName: 'xh.io',
-                note: 'Maximum cell count to export to excel as fully formatted table. Exports with cell counts that exceed this value this will remove the table formatting in order to free up heap space.'
+                note: 'Configures exporting data to Excel.'
             ],
             xhIdleTimeoutMins: [
                 valueType: 'int',

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -128,6 +128,13 @@ class BootStrap {
                 groupName: 'xh.io',
                 note: 'True to enable the log viewer included with the Hoist Admin console as well as the associated server-side endpoints.'
             ],
+            xhExportTableCellThreshold: [
+                valueType: 'int',
+                defaultValue: 100000,
+                clientVisible: true,
+                groupName: 'xh.io',
+                note: 'Maximum cell count to export to excel as fully formatted table. Exports with cell counts that exceed this value this will remove the table formatting in order to free up heap space.'
+            ],
             xhIdleTimeoutMins: [
                 valueType: 'int',
                 defaultValue: -1,

--- a/grails-app/services/io/xh/hoist/export/GridExportImplService.groovy
+++ b/grails-app/services/io/xh/hoist/export/GridExportImplService.groovy
@@ -25,6 +25,16 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.*
 
 import java.awt.Color
 
+/**
+ * Service to export row data to Excel or CSV.
+ *
+ * Uses the following properties from `xhExportConfig`:
+ *
+ *      `streamingCellThreshold`:   Maximum cell count to export to Excel as fully formatted table. Exports with cell
+ *                                  counts that exceed this value this will use Apache POI's streaming API, which frees
+ *                                  up heap space at the expenses of removing the table formatting.
+ *                                  See https://poi.apache.org/components/spreadsheet/how-to.html#sxssf
+ */
 class GridExportImplService extends BaseService {
 
     def configService
@@ -87,7 +97,7 @@ class GridExportImplService extends BaseService {
         def tableRows = rows.size()
         def tableColumns = rows[0]['data'].size()
         def tableCells = tableRows * tableColumns
-        def useStreamingAPI = tableCells > configService.getInt('xhExportTableCellThreshold')
+        def useStreamingAPI = tableCells > config.streamingCellThreshold
         def maxDepth = rows.collect{it.depth}.max()
         def grouped = maxDepth > 0
         def wb
@@ -307,6 +317,10 @@ class GridExportImplService extends BaseService {
         temp.delete()
 
         return ret
+    }
+
+    private Map getConfig() {
+        configService.getJSONObject('xhExportConfig')
     }
 
 }

--- a/grails-app/services/io/xh/hoist/export/GridExportImplService.groovy
+++ b/grails-app/services/io/xh/hoist/export/GridExportImplService.groovy
@@ -23,6 +23,8 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.*
 
 class GridExportImplService extends BaseService {
 
+    def configService
+
     /**
      * Return map suitable for rendering file with grails controller render() method
      */
@@ -80,7 +82,8 @@ class GridExportImplService extends BaseService {
     private byte[] renderExcelFile(List rows, List meta, Boolean asTable) {
         def tableRows = rows.size()
         def tableColumns = rows[0]['data'].size()
-        def useStreamingAPI = tableRows > 10000
+        def tableCells = tableRows * tableColumns
+        def useStreamingAPI = tableCells > configService.getInt('xhExportTableCellThreshold')
         def wb
 
         if (useStreamingAPI) {


### PR DESCRIPTION
See issue: #74
See corresponding hoist-react pr: https://github.com/xh/hoist-react/pull/1848

Went with a single config rather than the suggested json config, because I felt that individual configs (we currently only have one) are easier to document with the config note