### PR TITLE
Specify DB indices for selected domain classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Pref and Config Differ now record the admin user applying any changes via these tools.
 * Fix bug with monitoring when monitor script times out.
 
+### ⚙️ Technical
+
+* Specify default DB indices on a small number of bundled domain classes.
+
 [Commit Log](https://github.com/xh/hoist-core/compare/v8.1.0...develop)
 
 

--- a/grails-app/domain/io/xh/hoist/clienterror/ClientError.groovy
+++ b/grails-app/domain/io/xh/hoist/clienterror/ClientError.groovy
@@ -27,6 +27,7 @@ class ClientError implements JSONFormat {
         cache true
         error type: 'text'
         msg type: 'text'
+        dateCreated index: 'idx_xh_client_error_date_created'
     }
 
     static constraints = {

--- a/grails-app/domain/io/xh/hoist/pref/UserPreference.groovy
+++ b/grails-app/domain/io/xh/hoist/pref/UserPreference.groovy
@@ -23,6 +23,7 @@ class UserPreference implements JSONFormat {
         table 'xh_user_preference'
         cache true
         userValue type: 'text'
+        username index: 'idx_xh_user_preference_username'
     }
 
     static constraints = {

--- a/grails-app/domain/io/xh/hoist/track/TrackLog.groovy
+++ b/grails-app/domain/io/xh/hoist/track/TrackLog.groovy
@@ -27,7 +27,8 @@ class TrackLog implements JSONFormat {
     static mapping = {
         table 'xh_track_log'
         cache true
-        data type: "text"
+        data type: 'text'
+        dateCreated index: 'idx_xh_track_log_date_created'
     }
 
     static constraints = {


### PR DESCRIPTION
I've noticed some poor performance loading activity tracking with some client apps. I think/hope it's reasonable to use this GORM mapping config to setup some default DB indices on fields we know we use for queries. 

I didn't want to go overboard here - we could remove the `UserPreference` index if we wanted to pare back.

If merged happy to test a snap build against a client app running on SQL Server to a) ensure this syntax doesn't cause any issues and b) verify if there is a noticeable performance improvement.