### PR TITLE
Add simple MemoryMonitoringService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   runtime in the Hoist Admin Console.
 * HTML-encode certain user-provided params to XhController endpoints (e.g. track, clientErrors,
   feedback) to sanitize before storing / emailing.
+* Added new `MemoryMonitoringService` to sample and return simple statistics on heap (memory) usage
+  from the JVM runtime. Stores a rolling history of snapshots on a configurable interval.
 
 [Commit Log](https://github.com/xh/hoist-core/compare/v8.6.1...develop)
 

--- a/grails-app/controllers/io/xh/hoist/admin/MemoryMonitorAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/MemoryMonitorAdminController.groovy
@@ -1,0 +1,23 @@
+package io.xh.hoist.admin
+
+import io.xh.hoist.BaseController
+import io.xh.hoist.security.Access
+
+@Access(['HOIST_ADMIN'])
+class MemoryMonitorAdminController extends BaseController {
+
+    def memoryMonitoringService
+
+    def snapshots() {
+        renderJSON(memoryMonitoringService.snapshots)
+    }
+
+    def takeSnapshot() {
+        renderJSON(memoryMonitoringService.takeSnapshot())
+    }
+
+    def requestGc() {
+        renderJSON(memoryMonitoringService.requestGc())
+    }
+
+}

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -168,6 +168,12 @@ class BootStrap {
                 groupName: 'xh.io',
                 note: 'Configures automatic cleanup and archiving of log files. Files older than "archiveAfterDays" will be moved into zipped bundles within the specified "archiveFolder".'
             ],
+            xhMemoryMonitorIntervalSecs: [
+                valueType: 'int',
+                defaultValue: 60,
+                groupName: 'xh.io',
+                note: 'Interval in seconds on which the Hoist MemoryMonitoringService should sample current JVM Heap usage.'
+            ],
             xhMonitorConfig: [
                 valueType: 'json',
                 defaultValue: [

--- a/grails-app/services/io/xh/hoist/monitor/MemoryMonitoringService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MemoryMonitoringService.groovy
@@ -1,0 +1,94 @@
+package io.xh.hoist.monitor
+
+import io.xh.hoist.BaseService
+import io.xh.hoist.util.Timer
+
+import java.util.concurrent.ConcurrentHashMap
+
+import static io.xh.hoist.util.DateTimeUtils.SECONDS
+import static java.lang.Runtime.getRuntime
+
+/**
+ * Service to sample and return simple statistics on heap (memory) usage from the JVM runtime.
+ * Collects rolling history of snapshots on a configurable timer.
+ */
+class MemoryMonitoringService extends BaseService {
+
+    private Map<Long, Map> _snapshots = new ConcurrentHashMap()
+    private Timer _snapshotTimer
+
+    void init() {
+        _snapshotTimer = createTimer(
+            interval: 'xhMemoryMonitorIntervalSecs',
+            intervalUnits: SECONDS,
+            runFn: this.&takeSnapshot
+        )
+    }
+
+    /**
+     * Returns a map of previous JVM memory usage snapshots, keyed by ms timestamp of snapshot.
+     */
+    Map getSnapshots() {
+        return _snapshots
+    }
+
+    /**
+     * Take a snapshot of JVM memory usage, store in this service's in-memory history, and return.
+     */
+    Map takeSnapshot() {
+        def newSnap = getStats()
+        _snapshots.put(System.currentTimeMillis(), newSnap)
+
+        // Don't allow snapshot history to grow endlessly - cap @ 1440 samples, i.e. 24 hours of
+        // history if left at default config interval of one snap/minute.
+        if (_snapshots.size() > 1440) {
+            Date oldest = _snapshots.keys().toList().min()
+            _snapshots.remove(oldest)
+        }
+
+        return newSnap
+    }
+
+    /**
+     * Request an immediate garbage collection, with before and after usage snapshots.
+     */
+    Map requestGc() {
+        def before = takeSnapshot(),
+            start = System.currentTimeMillis()
+
+        System.gc()
+
+        def after = takeSnapshot()
+        return [
+            before: before,
+            after: after,
+            elapsedMs: System.currentTimeMillis() - start
+        ]
+    }
+
+
+    //------------------------
+    // Implementation
+    //------------------------
+    private Map getStats() {
+        def mb = 1024 * 1024,
+            total = runtime.totalMemory(),
+            free = runtime.freeMemory(),
+            used = total - free,
+            max = runtime.maxMemory(),
+            round = {it -> Math.round(it * 100) / 100}
+
+        return [
+            totalHeapMb: round(total / mb),
+            maxHeapMb: round(max / mb),
+            usedHeapMb: round(used / mb),
+            freeHeapMb: round(free / mb),
+            usedPctTotal: round((used * 100) / total),
+            totalPctMax: round((total * 100) / max)
+        ]
+    }
+
+    void clearCaches() {
+        this._snapshots.clear()
+    }
+}

--- a/src/main/groovy/io/xh/hoist/util/Timer.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Timer.groovy
@@ -41,20 +41,20 @@ class Timer implements AsyncSupport {
     final Closure runFn
 
     /**
-     * Interval between runs.  Specify as a number, closure, or string.  The units for this
-     * argument are defined by intervalUnits property.  If value is not positive, the job will not run.
+     * Interval between runs. Specify as a number, closure, or string. The units for this argument
+     * are defined by intervalUnits property. If value is not positive, the job will not run.
      *
-     * If specified as a function, the value will be recomputed after every run. If specified as a string,
-     * the value will be assumed to be a config key, and will be looked up after every run.
+     * If specified as a function, the value will be recomputed after every run. If specified as a
+     * string, the value will be assumed to be a config key and will be looked up after every run.
      */
     final Object interval
 
     /**
-     * Max time to let function run before cancelling. Specify as a number, closure, or string.  The units for this
-     * argument are defined by timeoutUnits property.  Default is 3 mins.
+     * Max time to let function run before cancelling. Specify as a number, closure, or string.
+     * The units for this argument are defined by timeoutUnits property. Default is 3 mins.
      *
-     * If specified as a function, the value will be re-computed after every run. If specified as a string,
-     * the value will be assumed to be a config key, and will be looked up after every run.
+     * If specified as a function, the value will be re-computed after every run. If specified as a
+     * string, the value will be assumed to be a config key, and will be looked up after every run.
      */
     final Object timeout
 
@@ -105,9 +105,8 @@ class Timer implements AsyncSupport {
     static ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>())
 
     /**
-     * Applications should not typically use this constructor directly.  Timers
-     * are typically created by services using the createTimer() method on
-     * the service itself.
+     * Applications should not typically use this constructor directly. Timers are typically
+     * created by services using the createTimer() method supplied by io.xh.hoist.BaseService.
      */
     Timer(Map config) {
         owner = config.owner
@@ -278,5 +277,3 @@ class Timer implements AsyncSupport {
         }
     }
 }
-
-


### PR DESCRIPTION
+ Takes and stores a limited history of memory usage snapshots, based on JVM runtime stats.