### PR TITLE
Serialize NaN and Infinity to `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.2.0 - unreleased
+
+### 🐞 Bug Fixes
+* Restore JSON Serialization of `NaN` and `Infinity` as `null`.  
+This had long been the standard Hoist JSON serialization for `Double`s and `Float`s but 
+was regressed in v7.0 with the move to Jackson-based JSON serialization.
+
+
 ## 9.1.1 - 2021-01-27
 
 ### ⚙️ Technical

--- a/src/main/groovy/io/xh/hoist/json/JSONSerializer.java
+++ b/src/main/groovy/io/xh/hoist/json/JSONSerializer.java
@@ -46,7 +46,9 @@ public class JSONSerializer {
                 .addSerializer(Instant.class, new InstantSerializer())
                 .addSerializer(GString.class, new GStringSerializer())
                 .addSerializer(JSONFormatCached.class, new JSONFormatCachedSerializer())
-                .addSerializer(JSONFormat.class, new JSONFormatSerializer());
+                .addSerializer(JSONFormat.class, new JSONFormatSerializer())
+                .addSerializer(Double.class, new DoubleSerializer())
+                .addSerializer(Float.class, new FloatSerializer());
         
         registerModules(module);
     }

--- a/src/main/groovy/io/xh/hoist/json/serializer/DoubleSerializer.java
+++ b/src/main/groovy/io/xh/hoist/json/serializer/DoubleSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2021 Extremely Heavy Industries Inc.
+ */
+
+package io.xh.hoist.json.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class DoubleSerializer extends StdSerializer<Double> {
+
+    public DoubleSerializer() {
+        this(null);
+    }
+
+    public DoubleSerializer(Class<Double> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Double value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if (value.isNaN() || value.isInfinite()) {
+            jgen.writeNull();
+        } else {
+            jgen.writeNumber(value);
+        }
+    }
+
+}

--- a/src/main/groovy/io/xh/hoist/json/serializer/DoubleSerializer.java
+++ b/src/main/groovy/io/xh/hoist/json/serializer/DoubleSerializer.java
@@ -25,10 +25,10 @@ public class DoubleSerializer extends StdSerializer<Double> {
 
     @Override
     public void serialize(Double value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        if (value.isNaN() || value.isInfinite()) {
-            jgen.writeNull();
-        } else {
+        if (Double.isFinite(value)) {
             jgen.writeNumber(value);
+        } else {
+            jgen.writeNull();
         }
     }
 

--- a/src/main/groovy/io/xh/hoist/json/serializer/FloatSerializer.java
+++ b/src/main/groovy/io/xh/hoist/json/serializer/FloatSerializer.java
@@ -25,10 +25,10 @@ public class FloatSerializer extends StdSerializer<Float> {
 
     @Override
     public void serialize(Float value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        if (value.isNaN() || value.isInfinite()) {
-            jgen.writeNull();
-        } else {
+        if (Float.isFinite(value)) {
             jgen.writeNumber(value);
+        } else {
+            jgen.writeNull();
         }
     }
 }

--- a/src/main/groovy/io/xh/hoist/json/serializer/FloatSerializer.java
+++ b/src/main/groovy/io/xh/hoist/json/serializer/FloatSerializer.java
@@ -1,0 +1,34 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2021 Extremely Heavy Industries Inc.
+ */
+
+package io.xh.hoist.json.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class FloatSerializer extends StdSerializer<Float> {
+
+    public FloatSerializer() {
+        this(null);
+    }
+
+    public FloatSerializer(Class<Float> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Float value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if (value.isNaN() || value.isInfinite()) {
+            jgen.writeNull();
+        } else {
+            jgen.writeNumber(value);
+        }
+    }
+}


### PR DESCRIPTION
This is consistent with how we serialized Floats and Doubles pre-jackson, and consistent with how the react client expects to receive these numbers. 