### PR TITLE
Fix: Excel table area must have minimum height of 1

### DIFF
--- a/grails-app/services/io/xh/hoist/export/GridExportImplService.groovy
+++ b/grails-app/services/io/xh/hoist/export/GridExportImplService.groovy
@@ -115,7 +115,7 @@ class GridExportImplService extends BaseService {
         if (asTable) {
             // Create table
             XSSFTable xssfTable = sheet.createTable()
-            AreaReference tableRange = new AreaReference(new CellReference(0, 0), new CellReference(tableRows - 1, tableColumns - 1), SpreadsheetVersion.EXCEL2007)
+            AreaReference tableRange = new AreaReference(new CellReference(0, 0), new CellReference(Math.max(1, tableRows - 1), tableColumns - 1), SpreadsheetVersion.EXCEL2007)
             CTTable table = xssfTable.getCTTable()
             table.setRef(tableRange.formatAsString())
             table.setDisplayName('Export')


### PR DESCRIPTION
Relates to and resolves bug for empty grid exports in https://github.com/xh/hoist-react/issues/2376
- Realized that the error stems from creating a table area of 0 -- at a minimum it must have row height of 1