### PR TITLE
Respect failed/inactive status set by monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### 🐞 Bug Fixes
 
-* `GridExportImplService` now handles Excel table exports containing no data rows. Previously, the Excel file required 
-repair, during which process all table and column header formatting was removed.
+* `GridExportImplService` now handles Excel table exports containing no data rows. Previously, the
+  Excel file required repair, during which process all table and column header formatting was
+  removed.
+* Status Monitors no longer evaluate metric-based thresholds if an app-level check implementation
+  has already set marked the result with a `FAIL` or `INACTIVE` status.
 
 [Commit Log](https://github.com/xh/hoist-core/compare/v9.2.0...develop)
 
@@ -13,9 +16,9 @@ repair, during which process all table and column header formatting was removed.
 
 ### 🐞 Bug Fixes
 
-* Restore JSON Serialization of `NaN` and `Infinity` as `null`.
-  This had long been the standard Hoist JSON serialization for `Double`s and `Float`s but was
-  regressed in v7.0 with the move to Jackson-based JSON serialization.
+* Restore JSON Serialization of `NaN` and `Infinity` as `null`. This had long been the standard
+  Hoist JSON serialization for `Double`s and `Float`s but was regressed in v7.0 with the move to
+  Jackson-based JSON serialization.
 
 [Commit Log](https://github.com/xh/hoist-core/compare/v9.1.1...v9.2.0)
 

--- a/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
@@ -57,8 +57,12 @@ class MonitorResultService extends BaseService implements AsyncSupport {
                 result.status = OK
             }
 
-            // Then (maybe) evaluate thresholds for metric-based checks.
-            evaluateThresholds(monitor, result)
+            // If a check has been marked as inactive or failed, skip any metric-based evaluation -
+            // the check implementation has already decided this should not run or is failing.
+            // Otherwise, eval metrics to confirm a final status.
+            if (result.status != INACTIVE && result.status != FAIL) {
+                evaluateThresholds(monitor, result)
+            }
         } catch (Exception e) {
             result.message = e instanceof TimeoutException ?
                                 "Monitor run timed out after $timeoutSeconds seconds." :


### PR DESCRIPTION
+ Status check implementations should be able to mark a check as failed or inactive internally - hopefully installing a message to explain - without the subsequent metric-based evaluation overwriting such a status and message.