### PR TITLE
Make 'excelTable' downgrades to 'excel' obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 10.0.0-SNAPSHOT - unreleased
+
+### 🎁 New Features
+
+* `xhExportConfig.streamingCellThreshold` config is now obsolete. With cell style re-use, Excel 
+  tables are no longer subject to downgrading because of cell style limitations (previously limited
+  to 64,000).
+
 ## 9.2.3 - 2021-06-24
 
 ### 🐞 Technical


### PR DESCRIPTION
+ Cache cell styles for re-use across a column's rows at the same depth (previously limited to max of 64,000 styles, and we were creating a new style for each formatted or grouped cell)
+ Remove obsolete code to downgrade XSSF workbooks to SXSSF workbook due to style constraints