### PR TITLE
Unwind removing use of streamingCellThreshold to downgrade excelTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### 🎁 New Features
 
-* `xhExportConfig.streamingCellThreshold` config is now obsolete. With cell style re-use, Excel 
-  tables are no longer subject to downgrading because of cell style limitations (previously limited
-  to 64,000).
+* Excel cell styles with grouped colors are now cached for re-use, avoiding previously common file error that limits 
+  Excel tables to 64,000 total styles.
 
 ## 9.2.3 - 2021-06-24
 


### PR DESCRIPTION
Discussed w/Lee yesterday - will revisit how to make tree grid exports more performant. In the meantime, we do need the streamingCellThreshold to downgrade large exports (realized the limitation in performance was not style-related, though the change to cache groupedColors prevents the apache error of exceeding 64k styles)