### PR TITLE
Build in support for sizingMode to Hoist

### DIFF
--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -233,6 +233,12 @@ class BootStrap {
                 local: true,
                 groupName: 'xh.io',
                 note: 'Visual theme for the client application - "light" or "dark".'
+            ],
+            xhSizingMode: [
+                type: 'string',
+                defaultValue: 'standard',
+                groupName: 'xh.io',
+                note: 'Sizing mode used throughout application.'
             ]
         ])
     }


### PR DESCRIPTION
Add `xhSizingMode` pref to store the built-in sizing mode

See hoist-react PR: https://github.com/xh/hoist-react/pull/2593
See toolbox PR: xh/toolbox#518