### PR TITLE
Block sending unfiltered email from local dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.3.2 - 2021-10-01
+
+* `EmailService` now requires an override or filter config before sending any mails in local
+  development mode.
+* `ClientErrorEmailService` now relays any client URL captured with the error.
+
+[Commit Log](https://github.com/xh/hoist-core/compare/v9.3.1...v9.3.2)
+
 ## 9.3.1 - 2021-08-20
 
 * Bootstrap new `xhSizingMode` core preference.

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -9,6 +9,7 @@ package io.xh.hoist.util
 
 import com.grack.nanojson.JsonParser
 import com.grack.nanojson.JsonParserException
+import grails.util.Environment
 import grails.util.Holders
 import io.xh.hoist.AppEnvironment
 import io.xh.hoist.BaseService
@@ -67,6 +68,13 @@ class Utils {
 
     static Boolean getIsProduction() {
         return appEnvironment == AppEnvironment.PRODUCTION
+    }
+
+    /**
+     * Indicates if app is running in local development mode, regardless of AppEnvironment.
+     */
+    static Boolean getIsLocalDevelopment() {
+        return Environment.isDevelopmentMode()
     }
 
     static ConfigService getConfigService() {
@@ -160,5 +168,5 @@ class Utils {
 
         return ret
     }
-    
+
 }


### PR DESCRIPTION
+ When running in local development mode, EmailService now requires either a filter or override config to be active, to ensure that a dev has placed some constraints on where dev emails will go.