### PR TITLE
Update user agent matchers for Edge browser

### DIFF
--- a/src/main/groovy/io/xh/hoist/browser/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Utils.groovy
@@ -18,7 +18,9 @@ class Utils {
     
     private static Map<String, Browser> BROWSERS_MATCHERS = [
             'Firefox': FIREFOX, // Firefox must come before "; rv" to prevent identification as IE
-            'Edge': EDGE,
+            'EdgiOS': EDGE,     // iOS Edge
+            'EdgA': EDGE,       // Android Edge
+            'Edg': EDGE,        // Desktop Edge
             '; rv': IE,         // IE 11 specific useragent pattern
             'MSIE': IE,
             'Opera': OPERA,     // Opera must come before Chrome and Safari to prevent false positives
@@ -29,7 +31,9 @@ class Utils {
     ]
 
     private static Map<String, Map<String,String>> BROWSER_VERSION_MATCHERS = [
-            'Edge': [start: 'Edge/', end: null],
+            'EdgiOS': [start: 'EdgiOS/', end: ' '],
+            'EdgA': [start: 'EdgA/', end: null],
+            'Edg': [start: 'Edg/', end: null],
             '; rv': [start: '; rv:', end: ')'],
             'MSIE': [start: 'MSIE ', end: ';'],
             'Opera': [start: 'Opera/', end: null], // Opera must come before Chrome and Safari to prevent false positives


### PR DESCRIPTION
Used this (and my own devices) to determine the correct user agent strings to look for: https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#identifiers-for-microsoft-edge-on-various-platforms

Could not get my devices talking to my desktop so tested with these unit tests: 

```
    @Test
    void getBrowserDetectsDesktopEdge() {
        assertEquals(Browser.EDGE, Utils.getBrowser("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Safari/537.36 Edg/96.0.1054.41"));
    }

    @Test
    void getBrowserDetectsAndroidEdge() {
        assertEquals(Browser.EDGE, Utils.getBrowser("Mozilla/5.0 (Linux; Android 12; Pixel 4a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Mobile Safari/537.36 EdgA/96.0.1054.41"));
    }

    @Test
    void getBrowserDetectsIosEdge() {
        assertEquals(Browser.EDGE, Utils.getBrowser("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/95 Version/13.0.3 Safari/605.1.15"));
    }

    @Test
    void getBrowserDetectsSafari() {
        assertEquals(Browser.SAFARI, Utils.getBrowser("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15"));
    }

    @Test
    void getBrowserDetectsChrome() {
        assertEquals(Browser.CHROME, Utils.getBrowser("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36"));
    }

    @Test
    void getBrowserVersionDesktopEdge() {
        assertEquals("96.0.1054.41", Utils.getBrowserVersion("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Safari/537.36 Edg/96.0.1054.41"));
    }

    @Test
    void getBrowserVersionAndroidEdge() {
        assertEquals("96.0.1054.41", Utils.getBrowserVersion("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Safari/537.36 Edg/96.0.1054.41"));
    }

    @Test
    void getBrowserVersionIosEdge() {
        assertEquals("95", Utils.getBrowserVersion("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/95 Version/13.0.3 Safari/605.1.15"));
    }
```