### PR TITLE
Throw if bootRun task run against plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,10 @@ tasks.withType(GroovyCompile) {
 }
 bootJar.enabled = false
 
+tasks.bootRun.doFirst {
+    throw new RuntimeException('The bootRun task is not supported in hoist-core. If running in a "wrapper" config, ensure you run the task from your app, not the top-level wrapper.')
+}
+
 //------------------------
 // Maven publishing
 // This is a modified version of the gradle configs setup by the Grails plugin publishing plugin


### PR DESCRIPTION
+ Avoid confusion with local development in "wrapper" mode, with both hoist-core and an app setup in a multi-project gradle build.
+ Devs should ensure they run `bootRun` from their app-specific gradle scope, not the combined top-level scope created by the wrapper.