### PR TITLE
Impersonation + Server Restart bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 14.0.0-SNAPSHOT - unreleased
+
+### 🐞 Bug Fixes
+* Fixed a bug with impersonation not being properly ended, causing the ex-impersonator's session to break upon server restart.
+
 ## 13.2.0 - 2022-04-28
 
 ### 🎁 New Features

--- a/grails-app/services/io/xh/hoist/user/IdentityService.groovy
+++ b/grails-app/services/io/xh/hoist/user/IdentityService.groovy
@@ -120,7 +120,7 @@ class IdentityService extends BaseService {
         if (apparentUser != authUser) {
             trackImpersonate("Stopped impersonation", [target: apparentUser.username])
             logInfo("User '$authUser.username' has stopped impersonating user '$apparentUser.username'")
-            request.session[APPARENT_USER_KEY] = authUser
+            request.session[APPARENT_USER_KEY] = authUser.username
         }
     }
 


### PR DESCRIPTION
Hard to find but an easy fix. 

We were accidentally setting the session[APPARENT_USER_KEY] to the authUser object itself rather than its authUser.username string. This object was being converted into the desired username string so the bug was not apparent until server restart. The intended string values of session[APPARENT_USER_KEY] and session[AUTH_USER_KEY] are being properly persisted through a server restart, but the erroneous object value of session[APPARENT_USER_KEY] was not persisted during a server restart and was defaulting to null, resulting in the NullPointerException error.