### PR TITLE
`DateTimeUtils` tweak to support no-arg calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 15.0-SNAPSHOT - unreleased
 
+###  ⚙️ Technical
+* `DateTimeUtils` app/server timezone conversion utils default to current day/date if called without arguments.
 
 ## 14.0.0 - 2022-07-12
 
@@ -22,7 +24,6 @@
 * Fixed a bug with JSON Blob diffing.
 
 [Commit Log](https://github.com/xh/hoist-core/compare/v13.2.1...v13.2.2)
-
 
 ## 13.2.1 - 2022-05-27
 

--- a/grails-app/services/io/xh/hoist/environment/EnvironmentService.groovy
+++ b/grails-app/services/io/xh/hoist/environment/EnvironmentService.groovy
@@ -11,6 +11,7 @@ import grails.plugins.GrailsPlugin
 import grails.util.GrailsUtil
 import grails.util.Holders
 import io.xh.hoist.BaseService
+import io.xh.hoist.util.DateTimeUtils
 import io.xh.hoist.util.Utils
 
 /**
@@ -64,8 +65,10 @@ class EnvironmentService extends BaseService {
                 javaVersion:            System.getProperty('java.version'),
                 serverTimeZone:         serverTz.toZoneId().id,
                 serverTimeZoneOffset:   serverTz.getOffset(now),
+                serverDay:              DateTimeUtils.serverDay(),
                 appTimeZone:            appTz.toZoneId().id,
                 appTimeZoneOffset:      appTz.getOffset(now),
+                appDay:                 DateTimeUtils.appDay(),
                 webSocketsEnabled:      webSocketService.enabled,
         ]
 

--- a/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
@@ -11,6 +11,7 @@ import groovy.transform.CompileStatic
 
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
 
 import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE
 
@@ -43,32 +44,40 @@ class DateTimeUtils {
         return Utils.environmentService.appTimeZone
     }
 
+    static ZoneId getAppZoneId() {
+        return appTimeZone.toZoneId()
+    }
+
     static TimeZone getServerTimeZone() {
         return Utils.environmentService.serverTimeZone
     }
 
-    static LocalDate appDay(Date dt) {
-        dt.toInstant().atZone(appTimeZone.toZoneId()).toLocalDate()
+    static ZoneId getServerZoneId() {
+        return serverTimeZone.toZoneId()
     }
 
-    static LocalDate serverDay(Date dt) {
-        dt.toInstant().atZone(serverTimeZone.toZoneId()).toLocalDate()
+    static LocalDate appDay(Date forDate = null) {
+        forDate ? forDate.toInstant().atZone(appZoneId).toLocalDate() : LocalDate.now(appZoneId)
     }
 
-    static Date appStartOfDay(LocalDate localDate) {
-        Date.from(localDate.atStartOfDay().atZone(appTimeZone.toZoneId()).toInstant())
+    static LocalDate serverDay(Date forDate = null) {
+        forDate ? forDate.toInstant().atZone(serverZoneId).toLocalDate() : LocalDate.now(serverZoneId)
     }
 
-    static Date serverStartOfDay(LocalDate localDate) {
-        Date.from(localDate.atStartOfDay().atZone(serverTimeZone.toZoneId()).toInstant())
+    static Date appStartOfDay(LocalDate localDate = LocalDate.now(appZoneId)) {
+        Date.from(localDate.atStartOfDay().atZone(appZoneId).toInstant())
     }
 
-    static Date appEndOfDay(LocalDate localDate) {
-        Date.from(localDate.atTime(LocalTime.MAX).atZone(appTimeZone.toZoneId()).toInstant())
+    static Date serverStartOfDay(LocalDate localDate = LocalDate.now(serverZoneId)) {
+        Date.from(localDate.atStartOfDay().atZone(serverZoneId).toInstant())
     }
 
-    static Date serverEndOfDay(LocalDate localDate) {
-        Date.from(localDate.atTime(LocalTime.MAX).atZone(serverTimeZone.toZoneId()).toInstant())
+    static Date appEndOfDay(LocalDate localDate = LocalDate.now(appZoneId)) {
+        Date.from(localDate.atTime(LocalTime.MAX).atZone(appZoneId).toInstant())
+    }
+
+    static Date serverEndOfDay(LocalDate localDate = LocalDate.now(serverZoneId)) {
+        Date.from(localDate.atTime(LocalTime.MAX).atZone(serverZoneId).toInstant())
     }
 
     /**


### PR DESCRIPTION
+ App/server timezone conversion utils default to current day/date if called without arguments.
+ Added static getAppZoneId / getServerZoneId convenience getters