### PR TITLE
Monitor message will be prefixed instead of overriden on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+### ⚙️ Technical
+* Status monitor now prepends to the check-defined message on ERROR, FAIL, and WARN rather than overriding it.
+
 ## 14.3.0 - 2022-09-23
 
 * Excel exports now support per-cell data types and long values for `int` types.

--- a/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
@@ -109,7 +109,7 @@ class MonitorResultService extends BaseService {
 
         if (metric == null) {
             result.status = FAIL
-            result.message = "Monitor failed to compute metric \n\n$result.message"
+            result.prependMessage("Monitor failed to compute metric")
             return
         }
 

--- a/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
@@ -64,11 +64,10 @@ class MonitorResultService extends BaseService {
                 evaluateThresholds(monitor, result)
             }
         } catch (Exception e) {
-            result.message = (
-                                e instanceof TimeoutException ?
+            result.prependMessage(e instanceof TimeoutException ?
                                     "Monitor run timed out after $timeoutSeconds seconds." :
                                     e.message ?: e.class.name
-                             ) + " \n\n${result.message}"
+                                 )
             result.status = FAIL
             result.exception = e
         } finally {
@@ -124,11 +123,10 @@ class MonitorResultService extends BaseService {
 
         if (fail != null && (metric - fail) * sign > 0 && currSeverity < FAIL.severity) {
             result.status = FAIL
-            result.message = "Metric value is $verb failure limit of $fail $units \n\n$result.message"
+            result.prependMessage("Metric value is $verb failure limit of $fail $units")
         } else if (warn != null && (metric - warn) * sign > 0 && currSeverity < WARN.severity) {
             result.status = WARN
-            result.message = "Metric value is $verb warn limit of $warn $units \n\n$result.message"
+            result.prependMessage("Metric value is $verb warn limit of $warn $units")
         }
     }
-
 }

--- a/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorResultService.groovy
@@ -64,9 +64,11 @@ class MonitorResultService extends BaseService {
                 evaluateThresholds(monitor, result)
             }
         } catch (Exception e) {
-            result.message = e instanceof TimeoutException ?
-                                "Monitor run timed out after $timeoutSeconds seconds." :
-                                e.message ?: e.class.name
+            result.message = (
+                                e instanceof TimeoutException ?
+                                    "Monitor run timed out after $timeoutSeconds seconds." :
+                                    e.message ?: e.class.name
+                             ) + " \n\n${result.message}"
             result.status = FAIL
             result.exception = e
         } finally {
@@ -108,7 +110,7 @@ class MonitorResultService extends BaseService {
 
         if (metric == null) {
             result.status = FAIL
-            result.message =  'Monitor failed to compute metric'
+            result.message = "Monitor failed to compute metric \n\n$result.message"
             return
         }
 
@@ -122,10 +124,10 @@ class MonitorResultService extends BaseService {
 
         if (fail != null && (metric - fail) * sign > 0 && currSeverity < FAIL.severity) {
             result.status = FAIL
-            result.message = "Metric value is $verb failure limit of $fail $units"
+            result.message = "Metric value is $verb failure limit of $fail $units \n\n$result.message"
         } else if (warn != null && (metric - warn) * sign > 0 && currSeverity < WARN.severity) {
             result.status = WARN
-            result.message = "Metric value is $verb warn limit of $warn $units"
+            result.message = "Metric value is $verb warn limit of $warn $units \n\n$result.message"
         }
     }
 

--- a/src/main/groovy/io/xh/hoist/monitor/MonitorResult.groovy
+++ b/src/main/groovy/io/xh/hoist/monitor/MonitorResult.groovy
@@ -41,6 +41,12 @@ class MonitorResult implements JSONFormat {
         monitor.params ? JSONParser.parseObject(monitor.params) : [:]
     }
 
+    /** Combines the given string with 'message', separated by formatting */
+    void prependMessage(String prependStr) {
+        // Space character before the newlines is for fallback formatting in `hoist-react <= v51.0.0`
+        message = prependStr + (message ? " \n\n$message" : '')
+    }
+
     String getMinsInStatus () {
         def now = currentTimeMillis(),
             timeInStatus = now - lastStatusChanged.time


### PR DESCRIPTION
Small change to the way the Monitor sets the results.message variable on failure. It will now prepend the error, warn, or fail message but still always render the user-provided message afterwards, rather than overriding it. 

Backwards and forwards compatible:
Old hoist-core + new hoist-react = appears identical to old behavior, the non-success message overrides any user-provided
New hoist-core + old hoist-react = the messages on the monitor card are displayed on the same line, rather than a newline

Closes #268 