### PR TITLE
Added an `attachments` arg to EmailService.sendEmail()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 16.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* `EmailService.sendEmail()` now supports the `attachments` argument, for attaching one or more
+files to the email.
+
 ### 🐞 Bugfixes
 
 * Client Error timestamps will now correctly reflect the exact time the error was received on the

--- a/grails-app/services/io/xh/hoist/email/EmailService.groovy
+++ b/grails-app/services/io/xh/hoist/email/EmailService.groovy
@@ -43,6 +43,13 @@ class EmailService extends BaseService {
      *      html {String}           - html message
      *      view                    - gsp file path
      *      model                   - model to be applied to the view
+     *
+     * To attach file(s) to the email, include:
+     *
+     *      attachments {Map or List<Map>}
+     *             fileName {String}
+     *             contentType {String}
+     *             contentSource {byte[] or File or InputStreamSource}
      */
     void sendEmail(Map args) {
         def logMsg = "",
@@ -73,7 +80,13 @@ class EmailService extends BaseService {
                 env = Utils.appEnvironment.displayName.toUpperCase(),
                 envString = Utils.isProduction ? '' : " [$env]",
                 subj = args.subject + envString,
-                isAsync = args.containsKey('async') ? args.async : false
+                isAsync = args.containsKey('async') ? args.async : false,
+                isMultipart = args.containsKey('attachments') ,
+                attachments = []
+
+            if (isMultipart) {
+                attachments = args.attachments instanceof Map ? [args.attachments] : args.attachments
+            }
 
             if (!toRecipients) {
                 logDebug('No emails sent', 'no valid recipients found after filtering', logMsg)
@@ -88,6 +101,7 @@ class EmailService extends BaseService {
             }
 
             sendMail {
+                multipart isMultipart
                 async isAsync
                 from sender
                 to toRecipients.toArray()
@@ -107,6 +121,9 @@ class EmailService extends BaseService {
                     )
                 }
 
+                attachments.each { Map f ->
+                    attach f.fileName as String, f.contentType as String, f.contentSource
+                }
             }
 
             if (doLog) {


### PR DESCRIPTION
Added support for emailing attached files to the hoist-core `sendEmail()` method.