### PR TITLE
Safer TrackLog creation/querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 * `EmailService.sendEmail()` now supports the `attachments` argument, for attaching one or more
   files to the email.
+* A new `xhActivityTrackingConfig` soft-configuration entry will be automatically created to control
+  the behavior of built-in Activity Tracking (via `TrackService`).
+    * Most notably, the size of any `data` objects included with track log entries will be
+      constrained by this config, primarily to constrain memory usage when querying and serializing
+      large numbers of log entries for the Admin Console.
+    * Any track requests with data objects exceeding this length will be persisted, but without the
+      requested data.
 
 ### 💥 Breaking Changes
 

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -87,8 +87,12 @@ class XhController extends BaseController {
     // Tracking
     //------------------------
     def track(String category, String msg, String data, int elapsed, String severity) {
-        ensureClientUsernameMatchesSession()
+        if (!trackService.enabled) {
+            renderJSON(success: false, error: 'Activity Tracking disabled via config')
+            return
+        }
 
+        ensureClientUsernameMatchesSession()
         trackService.track(
             category: safeStr(category),
             msg: safeStr(msg),

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -52,6 +52,17 @@ class BootStrap {
 
     private void ensureRequiredConfigsCreated() {
         Utils.configService.ensureRequiredConfigsCreated([
+            xhActivityTrackingConfig: [
+                valueType: 'json',
+                defaultValue: [
+                    enabled: true,
+                    maxDataLength: 2000,
+                    maxRows: [default: 10000, limit: 25000, options: [1000, 5000, 10000, 25000]]
+                ],
+                clientVisible: true,
+                groupName: 'xh.io',
+                note: 'Configures built-in Activity Tracking via TrackService.'
+            ],
             xhAlertBannerConfig: [
                 valueType: 'json',
                 defaultValue: [enabled: true, interval: 30],

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -10,6 +10,7 @@ package io.xh.hoist.track
 import grails.events.EventPublisher
 import groovy.transform.CompileStatic
 import io.xh.hoist.BaseService
+import io.xh.hoist.config.ConfigService
 
 import static io.xh.hoist.browser.Utils.getBrowser
 import static io.xh.hoist.browser.Utils.getDevice
@@ -22,16 +23,20 @@ import static io.xh.hoist.util.Utils.getCurrentRequest
  * Service for tracking user activity within the application. This service provides a server-side
  * API for adding track log entries, while the client-side toolkits provide corresponding APIs
  * in Javascript. Track log entries are stored within the xh_track_log database table and are
- * viewable via the Hoist Admin Console's Client Activity > Activity grid.
+ * viewable via the Hoist Admin Console's Activity > Tracking tab.
  *
  * The choice of which activities to track is up to application developers. Typical use-cases
  * involve logging queries and tracking if / how often a given feature is actually used.
  *
- * Persistence of track logs to the database can be disabled (e.g. in a local dev environment)
- * with an instance config value of `disableTrackLog: true`.
+ * The `xhActivityTrackingConfig` soft-config can be used to configure this service, including
+ * disabling it completely. Separately, the `disableTrackLog` *instance* config can be used to
+ * disable only the *persistence* of new track logs while leaving logging and the admin client UI
+ * active / accessible (intended for local development environments).
  */
 @CompileStatic
 class TrackService extends BaseService implements EventPublisher {
+
+    ConfigService configService
 
     /**
      * Create a new track log entry. Username, browser info, and datetime will be set automatically.
@@ -64,24 +69,44 @@ class TrackService extends BaseService implements EventPublisher {
         }
     }
 
+    Boolean getEnabled() {
+        return conf.enabled == true
+    }
+
+    Map getConf() {
+        return configService.getMap('xhActivityTrackingConfig')
+    }
+
 
     //-------------------------
     // Implementation
     //-------------------------
     private void createTrackLog(Map params) {
-        def userAgent = currentRequest?.getHeader('User-Agent'),
-            values = [
-                username: params.username ?: authUsername,
-                impersonating: params.impersonating ?: (identityService.isImpersonating() ? username : null),
-                category: params.category ?: 'Default',
-                msg: params.msg,
-                userAgent: userAgent,
-                browser: getBrowser(userAgent),
-                device: getDevice(userAgent),
-                data: params.data ? serialize(params.data) : null,
-                elapsed: params.elapsed,
-                severity: params.severity ?: 'INFO'
-            ]
+        if (!enabled) {
+            logTrace("Activity tracking disabled via config", "track log with message [${params.msg}] will not be persisted")
+            return
+        }
+
+        String userAgent = currentRequest?.getHeader('User-Agent')
+        String data = params.data ? serialize(params.data) : null
+
+        if (data?.size() > (conf.maxDataLength as Integer)) {
+            logTrace("Track log with message [${params.msg}] includes ${data.size()} chars of JSON data", "exceeds limit of ${conf.maxDataLength}", "data will not be persisted")
+            data = null
+        }
+
+        Map values = [
+            username: params.username ?: authUsername,
+            impersonating: params.impersonating ?: (identityService.isImpersonating() ? username : null),
+            category: params.category ?: 'Default',
+            msg: params.msg,
+            userAgent: userAgent,
+            browser: getBrowser(userAgent),
+            device: getDevice(userAgent),
+            elapsed: params.elapsed,
+            severity: params.severity ?: 'INFO',
+            data: data
+        ]
 
         // Execute asynchronously after we get info from request, don't block application thread.
         // Save with additional try/catch to alert on persistence failures within this async block.
@@ -111,4 +136,5 @@ class TrackService extends BaseService implements EventPublisher {
             }
         }
     }
+
 }


### PR DESCRIPTION
New `xhActivityTrackingConfig` w/constraints for safer TrackLog creation/querying

+ Partial mitigation of a major TrackService pitfall - querying and serializing large numbers of TrackLogs that themselves contain large nested `data` maps requires a significant allocation of memory and in the worst case can crash the server.
+ New config limits maximum size of tracked data and provides configurable (and lowered) constraints on admin client querying.
+ Intended for use with corresponding hoist-react v56 updates to respect the same config on the client.