### PR TITLE
New DateTimeUtils.ensureServerTimeZoneIs() util method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### 🎁 New Features
 
-* Add support for the `caseSensitive` flag in log filtering endpoint.
+* Added support for the `caseSensitive` flag in log filtering endpoint.
+* Added new `DateTimeUtils.ensureServerTimeZoneIs()` utility method to validate that the server is
+  set to run in a given timezone. Applications requiring a specific timezone can call this method in
+  their `Bootstrap.groovy` file to ensure that the server is configured correctly.
 
 ## 16.1.0 - 2023-04-14
+
 * Enhance MemoryMonitoringService.
     - Produce and use more appropriate usage metric (used/max)
     - Produce GC statistics
@@ -15,6 +19,7 @@
 ## 16.0.1 - 2023-03-29
 
 ### 🐞 Bugfixes
+
 * Fixed a regression with 404 errors being incorrectly handled and not serialized as JSON.
 
 ## 16.0.0 - 2023-03-24

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -7,6 +7,7 @@
 package io.xh.hoist
 
 import grails.util.Holders
+import io.xh.hoist.util.DateTimeUtils
 import io.xh.hoist.util.Utils
 
 import static java.lang.Runtime.runtime
@@ -46,6 +47,7 @@ class BootStrap {
           Extremely Heavy - http://xh.io
             + ${runtime.availableProcessors()} available processors
             + ${String.format('%,d', (runtime.maxMemory() / 1000000).toLong())}mb available memory
+            + ${DateTimeUtils.serverZoneId} is the default timezone
 \n
         """)
     }

--- a/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
@@ -59,7 +59,8 @@ class DateTimeUtils {
     /**
      * Validate that the JVM is running in an expected/required TimeZone - will throw an exception
      * if the server is not running in the requested zone (or if the requested zone is invalid).
-     * Use within an application's `Bootstrap.groovy` to ensure the server is configured correctly.
+     * Call from an application's `Bootstrap.groovy` when a particular timezone is required (e.g.
+     * to match the timezone of the app's database server).
      */
     static void ensureServerTimeZoneIs(String zoneId) {
         def reqZone = ZoneId.of(zoneId)

--- a/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
@@ -56,6 +56,18 @@ class DateTimeUtils {
         return serverTimeZone.toZoneId()
     }
 
+    /**
+     * Validate that the JVM is running in an expected/required TimeZone - will throw an exception
+     * if the server is not running in the requested zone (or if the requested zone is invalid).
+     * Use within an application's `Bootstrap.groovy` to ensure the server is configured correctly.
+     */
+    static void ensureServerTimeZoneIs(String zoneId) {
+        def reqZone = ZoneId.of(zoneId)
+        if (serverZoneId != reqZone) {
+            throw new IllegalStateException("Server TimeZone is ${serverZoneId}, not ${reqZone} - please set JVM arg '-Duser.timezone=${reqZone}'")
+        }
+    }
+
     static LocalDate appDay(Date forDate = null) {
         forDate ? forDate.toInstant().atZone(appZoneId).toLocalDate() : LocalDate.now(appZoneId)
     }


### PR DESCRIPTION
+ Callable from e.g. app Bootstrap routines to enforce a particular time zone, if required by the app (e.g. due to interactions with a database running in a particular zone).
+ Log default zone in Hoist banner message on startup.
+ Fixes #215