### PR TITLE
Read and enforce new `xhExpectedServerTimeZone` config in Bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@
 * Updated `AlertBannerService` to append the environment name when creating/updating the `JsonBlob`
   used to persist banner state in a non-production environment. This better supports apps where
   e.g. `Beta` and `Production` environments share a database, but should display distinct banners.
-* Added new `DateTimeUtils.ensureServerTimeZoneIs()` utility method to validate that the server is
-  set to run in a given timezone. Applications requiring a specific timezone can call this method in
-  their `Bootstrap.groovy` file to ensure that the server is configured correctly.
+* Added new routine in `Bootstrap` to auto-create a new `xhExpectedServerTimeZone` app config with
+  a default value of "UTC". This config is now read at startup to validate that the server is
+  running in the expected zone, and will throw a fatal exception if it is invalid or does not match
+  the zone reported by Java.
+    * ⚠ **Note** - if your deployment environment has been customized to run in a zone other that
+      UTC, please add the new config entry with the desired zone prior to upgrading to this release
+      of Hoist Core.
 
 ## 16.1.0 - 2023-04-14
 

--- a/grails-app/services/io/xh/hoist/environment/EnvironmentService.groovy
+++ b/grails-app/services/io/xh/hoist/environment/EnvironmentService.groovy
@@ -11,7 +11,6 @@ import grails.plugins.GrailsPlugin
 import grails.util.GrailsUtil
 import grails.util.Holders
 import io.xh.hoist.BaseService
-import io.xh.hoist.util.DateTimeUtils
 import io.xh.hoist.util.Utils
 
 /**
@@ -89,12 +88,14 @@ class EnvironmentService extends BaseService {
     // Implementation
     //---------------------
     private TimeZone calcAppTimeZone() {
-        def id = configService.getString('xhAppTimeZone', 'GMT'),
-            availableIDs = TimeZone.availableIDs
-        if (!availableIDs.contains(id)) {
-            log.error("xhAppTimeZone '$id' not recognized - will fall back to GMT.")
+        def defaultZone = 'UTC',
+            configZoneId = configService.getString('xhAppTimeZone', defaultZone)
+
+        if (!TimeZone.availableIDs.contains(configZoneId)) {
+            log.error("Invalid xhAppTimeZone config: '$configZoneId' not a valid ZoneId - will fall back to $defaultZone.")
         }
-        return TimeZone.getTimeZone(id)
+
+        return TimeZone.getTimeZone(configZoneId)
     }
 
     private Collection<GrailsPlugin> getHoistGrailsPlugins() {

--- a/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
@@ -56,19 +56,6 @@ class DateTimeUtils {
         return serverTimeZone.toZoneId()
     }
 
-    /**
-     * Validate that the JVM is running in an expected/required TimeZone - will throw an exception
-     * if the server is not running in the requested zone (or if the requested zone is invalid).
-     * Call from an application's `Bootstrap.groovy` when a particular timezone is required (e.g.
-     * to match the timezone of the app's database server).
-     */
-    static void ensureServerTimeZoneIs(String zoneId) {
-        def reqZone = ZoneId.of(zoneId)
-        if (serverZoneId != reqZone) {
-            throw new IllegalStateException("Server TimeZone is ${serverZoneId}, not ${reqZone} - please set JVM arg '-Duser.timezone=${reqZone}'")
-        }
-    }
-
     static LocalDate appDay(Date forDate = null) {
         forDate ? forDate.toInstant().atZone(appZoneId).toLocalDate() : LocalDate.now(appZoneId)
     }


### PR DESCRIPTION
+ Auto-create config if required with default value of UTC.
+ Validate that the configured zone matches that of the JVM runtime, and throw a fatal exception to block server startup if it does not.
+ Update default `xhAppTimeZone` config value to UTC also (from GMT) - will only apply to brand-new instances, but seems a bit more standard/correct.
+ Removed static util previously added in #289 - this check goes farther than that change - it will be run automatically w/o requiring developers to update anything, and uses the config for increased visibility.