### PR TITLE
New ConnectionPoolMonitoringService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,33 @@
 # Changelog
 
+## 18.0-SNAPSHOT
+
+### 🎁 New Features
+
+* Lightweight monitoring collection of JDBC connection pool statistics, including counters for active vs idle
+  connections. Available via a new Admin Console tab for apps on `hoist-react >= 59.0`.
+
 ## 17.1.0 - 2023-08-08
 
 ### ⚙️ Technical
+
 * Additional improvements to support hot-reloading.
 
 ## 17.0.0 - 2023-07-27
+
 This release upgrades Hoist to the latest 6.0.0 version of Grails and upgrades related libraries.
 It should be fully compatible with Java 11 and Java 17.
 
 ### 🎁 New Features
+
 * This version of Hoist restores the ability to do development-time reloading via the java hotswap
- agent. [See the readme](https://github.com/xh/hoist-core/blob/develop/README.md#hot-reloading) for more information.
+  agent. [See the readme](https://github.com/xh/hoist-core/blob/develop/README.md#hot-reloading) for more information.
 
 ### ⚙️ Technical
+
 * The implementation of the `LogSupport` trait has been simplified, such that it no longer requires
-  an @SLF4J annotation, or `log` property to be provided.   Undocumented and problematic methods
- `logXXXInBase` were removed.
+  an @SLF4J annotation, or `log` property to be provided. Undocumented and problematic methods
+  `logXXXInBase` were removed.
 
 ### 📚 Libraries
 
@@ -27,6 +38,7 @@ It should be fully compatible with Java 11 and Java 17.
 ## 16.4.1 - 2023-07-13
 
 ### 🐞 Bugfixes
+
 * Make impersonation service more robust for applications with dynamic/lazy user generation.
 * Additional validation of parameters to '/userAdmin/users' endpoint.
 
@@ -39,7 +51,7 @@ It should be fully compatible with Java 11 and Java 17.
   standard output. Client-side support for this feature on a per-call basis added
   in `hoist-react >= 57.1`, can also be defaulted within the `xhActivityTrackingConfig` app config.
 * Deprecated config `xhAppVersionCheckEnabled` in favor of object based `xhAppVersionCheck`. Apps will
-  seamlessly migrate the existing value to this new config's `mode` flag.  This supports the new
+  seamlessly migrate the existing value to this new config's `mode` flag. This supports the new
   `forceRefresh` mode introduced in hoist-react v58.
 
 ## 16.3.0 - 2023-06-20

--- a/grails-app/controllers/io/xh/hoist/admin/ConnectionPoolMonitorAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/ConnectionPoolMonitorAdminController.groovy
@@ -1,0 +1,36 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2023 Extremely Heavy Industries Inc.
+ */
+package io.xh.hoist.admin
+
+import io.xh.hoist.BaseController
+import io.xh.hoist.security.Access
+
+@Access(['HOIST_ADMIN_READER'])
+class ConnectionPoolMonitorAdminController extends BaseController {
+
+    def connectionPoolMonitoringService
+
+    def index() {
+        def svc = connectionPoolMonitoringService
+        renderJSON(
+            enabled: svc.enabled,
+            snapshots: svc.snapshots,
+            poolConfiguration: svc.poolConfiguration
+        )
+    }
+
+    @Access(['HOIST_ADMIN'])
+    def takeSnapshot() {
+        renderJSON(connectionPoolMonitoringService.takeSnapshot())
+    }
+
+    @Access(['HOIST_ADMIN'])
+    def resetStats() {
+        renderJSON(connectionPoolMonitoringService.resetStats())
+    }
+
+}

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -121,6 +121,18 @@ class BootStrap {
                 groupName: 'xh.io',
                 note: 'Configures handling of client error reports. Errors are queued when received and processed every [intervalMins]. If more than [maxErrors] arrive within an interval, further reports are dropped to avoid storms of errors from multiple clients.'
             ],
+            xhConnPoolMonitoringConfig: [
+                valueType: 'json',
+                defaultValue: [
+                    enabled: true,
+                    snapshotInterval: 60,
+                    maxSnapshots: 1440,
+                    writeToLog: false
+                ],
+                clientVisible: false,
+                groupName: 'xh.io',
+                note: 'Configures built-in JDBC connection pool monitoring.'
+            ],
             xhEmailDefaultDomain: [
                 valueType: 'string',
                 defaultValue: 'xh.io',
@@ -215,7 +227,7 @@ class BootStrap {
                 ],
                 clientVisible: true,
                 groupName: 'xh.io',
-                note: 'Configures built-in Memory Monitoring.'
+                note: 'Configures built-in memory usage and GC monitoring.'
             ],
             xhMonitorConfig: [
                 valueType: 'json',

--- a/grails-app/services/io/xh/hoist/monitor/ConnectionPoolMonitoringService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/ConnectionPoolMonitoringService.groovy
@@ -1,0 +1,135 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2023 Extremely Heavy Industries Inc.
+ */
+
+package io.xh.hoist.monitor
+
+import io.xh.hoist.BaseService
+import io.xh.hoist.exception.DataNotAvailableException
+import io.xh.hoist.util.Timer
+import org.apache.tomcat.jdbc.pool.DataSource as PooledDataSource
+import org.apache.tomcat.jdbc.pool.PoolConfiguration
+import org.springframework.boot.jdbc.DataSourceUnwrapper
+
+import javax.sql.DataSource
+import java.util.concurrent.ConcurrentHashMap
+
+import static io.xh.hoist.util.DateTimeUtils.SECONDS
+import static java.lang.System.currentTimeMillis
+
+/**
+ * Service to sample and return simple statistics on JDBC connection pool usage from the app's
+ * primary injected DataSource. Collects rolling history of snapshots on a configurable timer.
+ */
+class ConnectionPoolMonitoringService extends BaseService {
+
+    private Map<Long, Map> _snapshots = new ConcurrentHashMap()
+    private Timer _snapshotTimer
+
+    def configService
+    def dataSource
+
+    void init() {
+        _snapshotTimer = createTimer(
+            interval: {enabled ? config.snapshotInterval * SECONDS: -1},
+            runFn: this.&takeSnapshot
+        )
+    }
+
+    boolean isEnabled() {
+        return config.enabled && pooledDataSource != null
+    }
+
+    /** @returns connection pool config properties, typically specified in Runtime.groovy. */
+    PoolConfiguration getPoolConfiguration() {
+        return pooledDataSource?.poolProperties
+    }
+
+    /** @returns map of previous pool usage snapshots, keyed by ms timestamp of snapshot. */
+    Map getSnapshots() {
+        return _snapshots
+    }
+
+    /** Take a snapshot of pool usage, add to in-memory history, and return. */
+    Map takeSnapshot() {
+        ensureEnabled()
+
+        def newSnap = getStats()
+        _snapshots[newSnap.timestamp] = newSnap
+
+        // Don't allow snapshot history to grow endlessly -
+        // default cap @ 1440 samples, i.e. 24 hours * 60 snaps/hour
+        if (_snapshots.size() > (config.maxSnapshots ?: 1440)) {
+            def oldest = _snapshots.min {it.key}
+            _snapshots.remove(oldest.key)
+        }
+
+        if (config.writeToLog) {
+            logInfo(newSnap)
+        }
+
+        return newSnap
+    }
+
+    /**
+     * Reset internal stats tracking on the pool.
+     * Note this is distinct from clearing the cache we maintain here of historical snapshots.
+     */
+    Map resetStats() {
+        ensureEnabled()
+        pooledDataSource.pool.resetStats()
+        this.takeSnapshot()
+    }
+
+
+    //------------------------
+    // Implementation
+    //------------------------
+    private Map getStats() {
+        def ds = pooledDataSource
+        return [
+            timestamp: currentTimeMillis(),
+            size: ds.size,
+            active: ds.active,
+            idle: ds.idle,
+            waitCount: ds.waitCount,
+            borrowed: ds.borrowedCount,
+            returned: ds.returnedCount,
+            created: ds.createdCount,
+            released: ds.releasedCount,
+            reconnected: ds.reconnectedCount,
+            removeAbandoned: ds.removeAbandonedCount,
+            releasedIdle: ds.releasedIdleCount
+        ]
+    }
+
+    private PooledDataSource _pooledDataSource
+    private boolean unwrapAttempted = false
+
+    private PooledDataSource getPooledDataSource() {
+        if (!_pooledDataSource && !unwrapAttempted) {
+            try {
+                unwrapAttempted = true
+                _pooledDataSource = DataSourceUnwrapper.unwrap(dataSource as DataSource, PooledDataSource.class)
+            } catch (e) {
+                logError("Failed to unwrap primary Datasource to org.apache.tomcat.jdbc.pool.DataSource - cannot monitor connection pool usage.", e)
+            }
+        }
+        return _pooledDataSource
+    }
+
+    private void ensureEnabled() {
+        if (!enabled) throw new DataNotAvailableException("Unable to monitor connection pool usage - service disabled via config, or no suitable DataSource detected.")
+    }
+
+    private Map getConfig() {
+        return configService.getMap('xhConnPoolMonitoringConfig')
+    }
+
+    void clearCaches() {
+        this._snapshots.clear()
+    }
+}


### PR DESCRIPTION
* Lightweight monitoring collection of JDBC connection pool statistics, including counters for active vs idle connections. Available via a new Admin Console tab for apps on `hoist-react >= 59.0`.
* Bootstrap new config to control the same.