### PR TITLE
Remove safe encoding when parsing alert banner requests

### DIFF
--- a/grails-app/controllers/io/xh/hoist/admin/AlertBannerAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/AlertBannerAdminController.groovy
@@ -25,13 +25,13 @@ class AlertBannerAdminController extends BaseController {
 
     @Access(['HOIST_ADMIN'])
     def setAlertSpec() {
-        alertBannerService.setAlertSpec(parseRequestJSON(safeEncode: true))
+        alertBannerService.setAlertSpec(parseRequestJSON())
         renderJSON(success: true)
     }
 
     @Access(['HOIST_ADMIN'])
     def setAlertPresets() {
-        alertBannerService.setAlertPresets(parseRequestJSONArray(safeEncode: true))
+        alertBannerService.setAlertPresets(parseRequestJSONArray())
         renderJSON(success: true)
 
     }


### PR DESCRIPTION
Requests to create or update alerts banner are currently being run through an OWASP encoder to escape HTML content tags, `&<>` prior to saving. The banner message is then saved with the escaped character, e.g. "P&L" becomes "P&amp;L". This string will still render correctly in the banner component, however saving the message further (like toggling active status) will have a cascading effect of the `&` being encoded again, making the message "P&amp;amp;L". which will then appear in the rendered banner as "P&amp;L". 

This PR removes safe encoding, because it does not actually provide defense against cross site scripting in its current use. Security when rendering the message is still ensured through the safe-by-default [react-markdown library](https://github.com/remarkjs/react-markdown) which is used when rendering strings in the banner. 