### PR TITLE
Tweaks to `DefaultRoleService`

### DIFF
--- a/grails-app/controllers/io/xh/hoist/admin/RoleAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/RoleAdminController.groovy
@@ -11,7 +11,7 @@ import static java.util.Collections.singleton
 class RoleAdminController extends BaseController {
 
     def defaultRoleAdminService,
-        defaultRoleEditService,
+        defaultRoleUpdateService,
         roleService
 
     @Access(['HOIST_ADMIN_READER'])
@@ -32,20 +32,20 @@ class RoleAdminController extends BaseController {
     def create() {
         ensureHoistRoleManager()
         Map roleSpec = parseRequestJSON()
-        Role role = defaultRoleEditService.create(roleSpec)
+        Role role = defaultRoleUpdateService.create(roleSpec)
         renderJSON(data: role)
     }
 
     def update() {
         ensureHoistRoleManager()
         Map roleSpec = parseRequestJSON()
-        Role role = defaultRoleEditService.update(roleSpec)
+        Role role = defaultRoleUpdateService.update(roleSpec)
         renderJSON(data: role)
     }
 
     def delete(String id) {
         ensureHoistRoleManager()
-        defaultRoleEditService.delete(id)
+        defaultRoleUpdateService.delete(id)
         renderJSON(success: true)
     }
 

--- a/grails-app/services/io/xh/hoist/role/provided/DefaultRoleAdminService.groovy
+++ b/grails-app/services/io/xh/hoist/role/provided/DefaultRoleAdminService.groovy
@@ -12,8 +12,8 @@ import static java.util.Collections.emptyMap
  * Requires applications to have opted-in to Hoist's {@link DefaultRoleService} for role management.
  * See that class for additional documentation and details.
  *
- * This class is intended to be used by its associated admin controller - apps should rarely (if
- * ever) need to interact with it directly.
+ * This class is intended to be used by Hoist and its default role admin UI - apps should
+ * rarely (if ever) need to interact with it directly.
  */
 class DefaultRoleAdminService extends BaseService {
     def roleService

--- a/grails-app/services/io/xh/hoist/role/provided/DefaultRoleUpdateService.groovy
+++ b/grails-app/services/io/xh/hoist/role/provided/DefaultRoleUpdateService.groovy
@@ -12,10 +12,10 @@ import static io.xh.hoist.role.provided.RoleMember.Type.*
  * Requires applications to have opted-in to Hoist's {@link DefaultRoleService} for role management.
  * See that class for additional documentation and details.
  *
- * This class is intended to be used by its associated admin controller - apps should rarely (if
- * ever) need to interact with it directly.
+ * This class is intended to be used by Hoist and its default role admin UI - apps should
+ * rarely (if ever) need to interact with it directly.
  */
-class DefaultRoleEditService extends BaseService {
+class DefaultRoleUpdateService extends BaseService {
     def roleService,
         trackService
 
@@ -54,12 +54,6 @@ class DefaultRoleEditService extends BaseService {
     }
 
 
-    /**
-    * Check a list of core roles required for Hoist/application operation - ensuring that these
-    * roles are present. Will create missing roles with supplied default values if not found.
-    *
-    * @param requiredRoles - List of maps of [name, category, notes, users, directoryGroups, roles]
-    */
     @Transactional
     void ensureRequiredRolesCreated(List<Map> roleSpecs) {
         List<Role> currRoles = Role.list()
@@ -98,12 +92,6 @@ class DefaultRoleEditService extends BaseService {
         logDebug("Validated presense of ${roleSpecs.size()} required roles", "created $created")
     }
 
-    /**
-    * Ensure that a user has been assigned a role.
-    *
-    * Typically called within Bootstrap code to ensure that a specific role is assigned to a
-    * dedicated admin user on startup.
-    */
     @Transactional
     void ensureUserHasRoles(HoistUser user, String roleName) {
         if (!user.hasRole(roleName)) {

--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -9,6 +9,7 @@ package io.xh.hoist.role.provided
 
 import grails.gorm.transactions.ReadOnly
 import io.xh.hoist.role.BaseRoleService
+import io.xh.hoist.user.HoistUser
 import io.xh.hoist.util.DateTimeUtils
 import io.xh.hoist.util.Timer
 
@@ -75,7 +76,7 @@ class DefaultRoleService extends BaseRoleService {
 
     def configService,
         ldapService,
-        defaultRoleEditService
+        defaultRoleUpdateService
 
     private Timer timer
     protected Map<String, Set<String>> _allRoleAssignments = emptyMap()
@@ -211,7 +212,7 @@ class DefaultRoleService extends BaseRoleService {
             ]
         ])
 
-        defaultRoleEditService.ensureRequiredRolesCreated([
+        ensureRequiredRolesCreated([
             [
                 name    : 'HOIST_ADMIN',
                 category: 'Hoist',
@@ -233,10 +234,34 @@ class DefaultRoleService extends BaseRoleService {
                 name    : 'HOIST_ROLE_MANAGER',
                 category: 'Hoist',
                 notes   : 'Hoist Role Managers can manage roles and their memberships.',
-                roles   : ['HOIST_ADMIN']
             ]
         ])
     }
+
+    /**
+     * Check a list of core roles required for Hoist/application operation - ensuring that these
+     * roles are present. Will create missing roles with supplied default values if not found.
+     *
+     * May be called within an implementation of ensureRequiredConfigAndRolesCreated().
+     *
+     * @param requiredRoles - List of maps of [name, category, notes, users, directoryGroups, roles]
+     */
+    void ensureRequiredRolesCreated(List<Map> roleSpecs) {
+        defaultRoleUpdateService.ensureRequiredRolesCreated(roleSpecs)
+    }
+
+    /**
+     * Ensure that a user has been assigned a role.
+     *
+     * Typically called within Bootstrap code to ensure that a specific role is assigned to a
+     * dedicated admin user on startup.
+     *
+     * May be called within an implementation of ensureRequiredConfigAndRolesCreated().
+     */
+    void ensureUserHasRoles(HoistUser user, String roleName) {
+        defaultRoleUpdateService.ensureUserHasRoles(user, roleName)
+    }
+
 
     //---------------------------
     // Implementation/Framework


### PR DESCRIPTION
+ HOIST_ROLE_MANAGER no longer granted to HOIST_ADMIN
+ API cleanup -- rename and hide defaultRoleEditService