### PR TITLE
Name of method ensureUserHasRoles is misleading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 19.0-SNAPSHOT
+
+### 💥 Breaking Changes
+
+* Method `ensureUserHasRoles` renamed to `ensureUserHasRole` in
+  `DefaultRoleService` and `DefaultRoleUpdateService`.  The method only accepts one role.
+
 ## 18.4.0 - 2024-02-13
 
 ### 🎁 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### 💥 Breaking Changes
 
-* Method `ensureUserHasRoles` renamed to `ensureUserHasRole` in
-  `DefaultRoleService` and `DefaultRoleUpdateService`.  The method only accepts one role.
+* Method `DefaultRoleService.ensureUserHasRoles` has been renamed to `assignRole`.
+  The new name more clearly describes that the code will actually grant an additional
+  role to the user.
 
 ## 18.4.0 - 2024-02-13
 

--- a/grails-app/services/io/xh/hoist/role/provided/DefaultRoleUpdateService.groovy
+++ b/grails-app/services/io/xh/hoist/role/provided/DefaultRoleUpdateService.groovy
@@ -93,11 +93,11 @@ class DefaultRoleUpdateService extends BaseService {
     }
 
     @Transactional
-    void ensureUserHasRole(HoistUser user, String roleName) {
+    void assignRole(HoistUser user, String roleName) {
         if (!user.hasRole(roleName)) {
             def role = Role.get(roleName)
             if (role) {
-                role.addToMembers(type: USER, name: user.username, createdBy: 'defaultRoleService')
+                role.addToMembers(type: USER, name: user.username, createdBy: 'defaultRoleUpdateService')
                 role.save(flush: true)
                 defaultRoleService.clearCaches()
             } else {

--- a/grails-app/services/io/xh/hoist/role/provided/DefaultRoleUpdateService.groovy
+++ b/grails-app/services/io/xh/hoist/role/provided/DefaultRoleUpdateService.groovy
@@ -93,7 +93,7 @@ class DefaultRoleUpdateService extends BaseService {
     }
 
     @Transactional
-    void ensureUserHasRoles(HoistUser user, String roleName) {
+    void ensureUserHasRole(HoistUser user, String roleName) {
         if (!user.hasRole(roleName)) {
             def role = Role.get(roleName)
             if (role) {

--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -258,8 +258,8 @@ class DefaultRoleService extends BaseRoleService {
      *
      * May be called within an implementation of ensureRequiredConfigAndRolesCreated().
      */
-    void ensureUserHasRoles(HoistUser user, String roleName) {
-        defaultRoleUpdateService.ensureUserHasRoles(user, roleName)
+    void ensureUserHasRole(HoistUser user, String roleName) {
+        defaultRoleUpdateService.ensureUserHasRole(user, roleName)
     }
 
 

--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -251,15 +251,17 @@ class DefaultRoleService extends BaseRoleService {
     }
 
     /**
-     * Ensure that a user has been assigned a role.
+     * Assign a role to a user.
+     *
+     * This method will be a no-op if the user already has the role provided.
      *
      * Typically called within Bootstrap code to ensure that a specific role is assigned to a
      * dedicated admin user on startup.
      *
      * May be called within an implementation of ensureRequiredConfigAndRolesCreated().
      */
-    void ensureUserHasRole(HoistUser user, String roleName) {
-        defaultRoleUpdateService.ensureUserHasRole(user, roleName)
+    void assignRole(HoistUser user, String roleName) {
+        defaultRoleUpdateService.assignRole(user, roleName)
     }
 
 


### PR DESCRIPTION
It was called `ensureUserHasRoles`, but accepts only one role and name is ambiguous.
I've renamed it to `assignRole`.

This would be a breaking change.  Corresponding toolbox PR is: https://github.com/xh/toolbox/pull/697

