### PR TITLE
Quiet log warnings from `LdapNetworkConnection` in `LdapService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 19.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* Quiet log warnings from `LdapNetworkConnection` in `LdapService` by setting the `LdapNetworkConnection` log level to `ERROR`.
+
 ## 18.5.0 - 2024-03-08
 
 ### 💥 Breaking Changes

--- a/src/main/groovy/io/xh/hoist/configuration/LogbackConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/configuration/LogbackConfig.groovy
@@ -127,6 +127,7 @@ class LogbackConfig {
             logger('org.hibernate', ERROR)
             logger('org.springframework', ERROR)
             logger('net.sf.ehcache', ERROR)
+            logger('org.apache.directory.ldap.client.api.LdapNetworkConnection', ERROR)
 
             // Turn off built-in global grails stacktrace logger.  It can easily swamp logs!
             // If needed, it can be (carefully) re-enabled by in admin console.


### PR DESCRIPTION
Quiet log warnings from `LdapNetworkConnection` in `LdapService` by setting the `LdapNetworkConnection` log level to `ERROR`.