### PR TITLE
Harmonize TrackLog and ClientError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 19.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* `ClientError` `JSONFormat` now accepts `impersonating` as a `nullable` field with at most `50` characters.
+* `TrackLog` `JSONFormat` now accepts three new fields:
+  * `appVersion` as a `nullable` field with at most `100` characters
+  * `appEnvironment` as a `nullable` field with at most `100` characters
+  * `url` as a `nullable` field with at most `500` characters
+* `TrackService` now logs `appVersion`, `appEnvironment`, and `url` fields in `TrackLog` records.
+
+### 💥 Breaking Changes
+
+* `XhController` endpoints `track` and `submitError` now expect to be visited via a `postJSON` request with a
+  `JSON` object posted in the `body`. This is pattern is preferred over using a `fetchJSON` request with
+  `params` posted in the request header.
+
 
 ## 18.5.1 - 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@
   * `appEnvironment` as a `nullable` field with at most `100` characters
   * `url` as a `nullable` field with at most `500` characters
 * `TrackService` now logs `appVersion`, `appEnvironment`, and `url` fields in `TrackLog` records.
-
-### 💥 Breaking Changes
-
 * `XhController` endpoints `track` and `submitError` now expect to be visited via a `postJSON` request with a
   `JSON` object posted in the `body`. This is pattern is preferred over using a `fetchJSON` request with
   `params` posted in the request header.
+
+### 💥 Breaking Changes
+
+* Requires `hoist-react >= 63.0` for client-side support of the new `track` and `submitError` endpoints.
+* Three new columns added to `xh_track_log` table: `app_version`, `app_environment`, and `url`. These columns
+  are nullable and have a maximum length of `100`, `100`, and `500` characters respectively.
 
 
 ## 18.5.1 - 2024-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,36 @@
 
 ## 19.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* New `TrackLogAdminService` and `ClientErrorAdminService` services provide a more bespoke set of methods
+  for querying `TrackLog` and `ClientError` records.
+  * These services utilize HQL criterion to allow for filters posted by the Hoist Admin Console to be applied
+    directly to the server-side query.
+* Client error reports now include `impersonating` field for additional troubleshooting context.
+    * ⚠ NOTE - this requires a new, nullable varchar(50) column be added to the xh_client_error
+      table in your app's configuration database. Review and run the following SQL, or an equivalent
+      suitable for the particular database you are using:
+
+      ```sql
+      ALTER TABLE `xh_client_error` ADD COLUMN `impersonating` VARCHAR(50) NULL;
+      ```
+* Track log reports now include `appVersion`, `appEnvironment`, and `url`,  fields for additional
+  activity context.
+  * ⚠ NOTE - this requires new, nullable varchar(100), nullable varchar(100), and nullable varchar(500)
+    columns to be added to the xh_track_log table in your app's configuration database for `appVersion`,
+    `appEnvironment`, and `url` respectively. Review and run the following SQL, or an equivalent
+    suitable for the particular database you are using:
+
+    ```sql
+    ALTER TABLE `xh_track_log` ADD COLUMN `appVersion` VARCHAR(100) NULL;
+    ALTER TABLE `xh_track_log` ADD COLUMN `appEnvironment` VARCHAR(100) NULL;
+    ALTER TABLE `xh_track_log` ADD COLUMN `url` VARCHAR(500) NULL;
+    ```
+* `TrackService` now logs `appVersion`, `appEnvironment`, and `url` fields in `TrackLog` records.
+
 ### ⚙️ Technical
 
-* `ClientError` `JSONFormat` now accepts `impersonating` as a `nullable` field with at most `50` characters.
-* `TrackLog` `JSONFormat` now accepts three new fields:
-  * `appVersion` as a `nullable` field with at most `100` characters
-  * `appEnvironment` as a `nullable` field with at most `100` characters
-  * `url` as a `nullable` field with at most `500` characters
-* `TrackService` now logs `appVersion`, `appEnvironment`, and `url` fields in `TrackLog` records.
 * `XhController` endpoints `track` and `submitError` now expect to be visited via a `postJSON` request with a
   `JSON` object posted in the `body`. This is pattern is preferred over using a `fetchJSON` request with
   `params` posted in the request header.
@@ -17,8 +39,6 @@
 ### 💥 Breaking Changes
 
 * Requires `hoist-react >= 63.0` for client-side support of the new `track` and `submitError` endpoints.
-* Three new columns added to `xh_track_log` table: `app_version`, `app_environment`, and `url`. These columns
-  are nullable and have a maximum length of `100`, `100`, and `500` characters respectively.
 
 
 ## 18.5.1 - 2024-03-08

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -93,14 +93,14 @@ class XhController extends BaseController {
         ensureClientUsernameMatchesSession()
         def query = parseRequestJSON()
         trackService.track(
-            category: query.category? safeEncode(query.category.toString()): null,
-            msg: query.msg? safeEncode(query.msg.toString()): null,
-            data: query.data ? parseObjectOrArray(safeEncode(query.data.toString())) : null,
-            logData: query.logData? (query.logData == 'true' || query.logData == 'false' ? parseBoolean(query.logData.toString()) : query.logData.toString()?.split(',')): null,
-            elapsed: query.elapsed? query.elapsed: null,
-            severity: query.severity? safeEncode(query.severity.toString()): null,
-            url: query.url? safeEncode(query.url.toString()): null,
-            appVersion: query.appVersion? safeEncode(query.appVersion.toString()): null
+            category: safeEncode(query.category as String),
+            msg: safeEncode(query.msg as String),
+            data: parseObjectOrArray(safeEncode(query.data as String)),
+            logData: (query.logData == 'true' || query.logData == 'false') ? parseBoolean(query.logData as String) : (query.logData as String).split(','),
+            elapsed: query.elapsed,
+            severity: safeEncode(query.severity as String),
+            url: safeEncode(query.url as String),
+            appVersion: safeEncode(query.appVersion as String)
         )
         renderJSON(success: true)
     }
@@ -234,11 +234,11 @@ class XhController extends BaseController {
         ensureClientUsernameMatchesSession()
         def query = parseRequestJSON()
         clientErrorService.submit(
-            query.msg? safeEncode(query.msg.toString()): null,
-            query.error? safeEncode(query.error.toString()): null,
-            query.appVersion? safeEncode(query.appVersion.toString()): null,
-            query.url? safeEncode(query.url.toString()): null,
-            query.userAlerted? parseBoolean(query.userAlerted.toString()): null
+            safeEncode(query.msg as String),
+            safeEncode(query.error as String),
+            safeEncode(query.appVersion as String),
+            safeEncode(query.url as String),
+            parseBoolean(query.userAlerted as String)
         )
         renderJSON(success: true)
     }

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -230,14 +230,15 @@ class XhController extends BaseController {
     //------------------------
     // Client Errors
     //------------------------
-    def submitError(String msg, String error, String appVersion, String url, boolean userAlerted) {
+    def submitError() {
         ensureClientUsernameMatchesSession()
+        def query = parseRequestJSON()
         clientErrorService.submit(
-            safeEncode(msg),
-            safeEncode(error),
-            safeEncode(appVersion),
-            safeEncode(url),
-            userAlerted
+            query.msg? safeEncode(query.msg.toString()): null,
+            query.error? safeEncode(query.error.toString()): null,
+            query.appVersion? safeEncode(query.appVersion.toString()): null,
+            query.url? safeEncode(query.url.toString()): null,
+            query.userAlerted? parseBoolean(query.userAlerted.toString()): null
         )
         renderJSON(success: true)
     }

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -89,17 +89,18 @@ class XhController extends BaseController {
     //------------------------
     // Tracking
     //------------------------
-    def track(String category, String msg, String data, String logData, int elapsed, String severity, String url, String appVersion) {
+    def track() {
         ensureClientUsernameMatchesSession()
+        def query = parseRequestJSON()
         trackService.track(
-            category: safeEncode(category),
-            msg: safeEncode(msg),
-            data: data ? parseObjectOrArray(safeEncode(data)) : null,
-            logData: logData == 'true' || logData == 'false' ? parseBoolean(logData) : logData?.split(','),
-            elapsed: elapsed,
-            severity: safeEncode(severity),
-            url: url,
-            appVersion: appVersion
+            category: query.category? safeEncode(query.category.toString()): null,
+            msg: query.msg? safeEncode(query.msg.toString()): null,
+            data: query.data ? parseObjectOrArray(safeEncode(query.data.toString())) : null,
+            logData: query.logData? (query.logData == 'true' || query.logData == 'false' ? parseBoolean(query.logData.toString()) : query.logData.toString()?.split(',')): null,
+            elapsed: query.elapsed? query.elapsed: null,
+            severity: query.severity? safeEncode(query.severity.toString()): null,
+            url: query.url? safeEncode(query.url.toString()): null,
+            appVersion: query.appVersion? safeEncode(query.appVersion.toString()): null
         )
         renderJSON(success: true)
     }

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -95,8 +95,8 @@ class XhController extends BaseController {
         trackService.track(
             category: safeEncode(query.category as String),
             msg: safeEncode(query.msg as String),
-            data: parseObjectOrArray(safeEncode(query.data as String)),
-            logData: (query.logData == 'true' || query.logData == 'false') ? parseBoolean(query.logData as String) : (query.logData as String).split(','),
+            data: query.data,
+            logData: query.logData,
             elapsed: query.elapsed,
             severity: safeEncode(query.severity as String),
             url: safeEncode(query.url as String),
@@ -238,7 +238,7 @@ class XhController extends BaseController {
             safeEncode(query.error as String),
             safeEncode(query.appVersion as String),
             safeEncode(query.url as String),
-            parseBoolean(query.userAlerted as String)
+            query.userAlerted as Boolean
         )
         renderJSON(success: true)
     }

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -89,7 +89,7 @@ class XhController extends BaseController {
     //------------------------
     // Tracking
     //------------------------
-    def track(String category, String msg, String data, String logData, int elapsed, String severity) {
+    def track(String category, String msg, String data, String logData, int elapsed, String severity, String url, String appVersion) {
         ensureClientUsernameMatchesSession()
         trackService.track(
             category: safeEncode(category),
@@ -97,7 +97,9 @@ class XhController extends BaseController {
             data: data ? parseObjectOrArray(safeEncode(data)) : null,
             logData: logData == 'true' || logData == 'false' ? parseBoolean(logData) : logData?.split(','),
             elapsed: elapsed,
-            severity: safeEncode(severity)
+            severity: safeEncode(severity),
+            url: url,
+            appVersion: appVersion
         )
         renderJSON(success: true)
     }

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -91,16 +91,16 @@ class XhController extends BaseController {
     //------------------------
     def track() {
         ensureClientUsernameMatchesSession()
-        def query = parseRequestJSON()
+        def query = parseRequestJSON([safeEncode: true])
         trackService.track(
-            category: safeEncode(query.category as String),
-            msg: safeEncode(query.msg as String),
+            category: query.category,
+            msg: query.msg,
             data: query.data,
             logData: query.logData,
             elapsed: query.elapsed,
-            severity: safeEncode(query.severity as String),
-            url: safeEncode(query.url as String),
-            appVersion: safeEncode(query.appVersion as String)
+            severity: query.severity,
+            url: query.url,
+            appVersion: query.appVersion
         )
         renderJSON(success: true)
     }
@@ -232,12 +232,12 @@ class XhController extends BaseController {
     //------------------------
     def submitError() {
         ensureClientUsernameMatchesSession()
-        def query = parseRequestJSON()
+        def query = parseRequestJSON([safeEncode: true])
         clientErrorService.submit(
-            safeEncode(query.msg as String),
-            safeEncode(query.error as String),
-            safeEncode(query.appVersion as String),
-            safeEncode(query.url as String),
+            query.msg as String,
+            query.error as String,
+            query.appVersion as String,
+            query.url as String,
             query.userAlerted as Boolean
         )
         renderJSON(success: true)

--- a/grails-app/domain/io/xh/hoist/clienterror/ClientError.groovy
+++ b/grails-app/domain/io/xh/hoist/clienterror/ClientError.groovy
@@ -15,18 +15,14 @@ import static io.xh.hoist.util.DateTimeUtils.appDay
 class ClientError implements JSONFormat {
 
     String username
-    String category
     String msg
     String error
     String browser
     String device
     String userAgent
-    String data
     String appVersion
     String appEnvironment
     String url
-    Integer elapsed
-    String severity
     boolean userAlerted = false
     Date dateCreated
     String impersonating
@@ -43,26 +39,21 @@ class ClientError implements JSONFormat {
     }
 
     static constraints = {
-        msg(maxSize: 255, nullable: true)
+        msg(nullable: true)
         username(maxSize: 50)
-        category(maxSize: 100)
         error(nullable: true)
         browser(nullable: true, maxSize: 100)
         device(nullable: true, maxSize: 100)
         userAgent(nullable: true)
-        data(nullable: true, validator: { Utils.isJSON(it) ?: 'default.invalid.json.message'})
         appVersion(nullable: true, maxSize: 100)
         appEnvironment(nullable: true, maxSize: 100)
         url(nullable: true, maxSize: 500)
-        elapsed(nullable: true)
         impersonating(nullable: true, maxSize: 50)
     }
 
     Map formatForJSON() {
         return [
                 id            : id,
-                category      : category,
-                severity      : severity,
                 msg           : msg,
                 error         : error,
                 username      : username,
@@ -75,8 +66,6 @@ class ClientError implements JSONFormat {
                 userAlerted   : userAlerted,
                 dateCreated   : dateCreated,
                 day           : appDay(dateCreated),
-                data: data,
-                elapsed: elapsed,
                 impersonating: impersonating
         ]
     }

--- a/grails-app/domain/io/xh/hoist/clienterror/ClientError.groovy
+++ b/grails-app/domain/io/xh/hoist/clienterror/ClientError.groovy
@@ -8,22 +8,28 @@
 package io.xh.hoist.clienterror
 
 import io.xh.hoist.json.JSONFormat
+import io.xh.hoist.util.Utils
 
 import static io.xh.hoist.util.DateTimeUtils.appDay
 
 class ClientError implements JSONFormat {
 
+    String username
+    String category
     String msg
     String error
-    String username
-    String userAgent
     String browser
     String device
+    String userAgent
+    String data
     String appVersion
     String appEnvironment
     String url
+    Integer elapsed
+    String severity
     boolean userAlerted = false
     Date dateCreated
+    String impersonating
 
     static mapping = {
         table 'xh_client_error'
@@ -37,20 +43,26 @@ class ClientError implements JSONFormat {
     }
 
     static constraints = {
-        msg(nullable: true)
-        error(nullable: true)
+        msg(maxSize: 255, nullable: true)
         username(maxSize: 50)
+        category(maxSize: 100)
+        error(nullable: true)
         browser(nullable: true, maxSize: 100)
         device(nullable: true, maxSize: 100)
         userAgent(nullable: true)
+        data(nullable: true, validator: { Utils.isJSON(it) ?: 'default.invalid.json.message'})
         appVersion(nullable: true, maxSize: 100)
         appEnvironment(nullable: true, maxSize: 100)
         url(nullable: true, maxSize: 500)
+        elapsed(nullable: true)
+        impersonating(nullable: true, maxSize: 50)
     }
 
     Map formatForJSON() {
         return [
                 id            : id,
+                category      : category,
+                severity      : severity,
                 msg           : msg,
                 error         : error,
                 username      : username,
@@ -62,7 +74,10 @@ class ClientError implements JSONFormat {
                 url           : url,
                 userAlerted   : userAlerted,
                 dateCreated   : dateCreated,
-                day           : appDay(dateCreated)
+                day           : appDay(dateCreated),
+                data: data,
+                elapsed: elapsed,
+                impersonating: impersonating
         ]
     }
 

--- a/grails-app/domain/io/xh/hoist/track/TrackLog.groovy
+++ b/grails-app/domain/io/xh/hoist/track/TrackLog.groovy
@@ -17,12 +17,17 @@ class TrackLog implements JSONFormat {
     String username
     String category
     String msg
+    String error
     String browser
     String device
     String userAgent
     String data
+    String appVersion
+    String appEnvironment
+    String url
     Integer elapsed
     String severity
+    boolean userAlerted = false
     Date dateCreated
     String impersonating
 
@@ -34,13 +39,17 @@ class TrackLog implements JSONFormat {
     }
 
     static constraints = {
+        msg(maxSize: 255, nullable: true)
         username(maxSize: 50)
         category(maxSize: 100)
-        msg(maxSize: 255)
+        error(nullable: true)
         browser(nullable: true, maxSize: 100)
         device(nullable: true, maxSize: 100)
         userAgent(nullable: true)
-        data(nullable: true, validator: {Utils.isJSON(it) ?: 'default.invalid.json.message'})
+        data(nullable: true, validator: { Utils.isJSON(it) ?: 'default.invalid.json.message'})
+        appVersion(nullable: true, maxSize: 100)
+        appEnvironment(nullable: true, maxSize: 100)
+        url(nullable: true, maxSize: 500)
         elapsed(nullable: true)
         impersonating(nullable: true, maxSize: 50)
     }
@@ -60,7 +69,12 @@ class TrackLog implements JSONFormat {
                 data: data,
                 elapsed: elapsed,
                 severity: severity,
-                impersonating: impersonating
+                impersonating: impersonating,
+                error         : error,
+                appVersion    : appVersion,
+                appEnvironment: appEnvironment,
+                url           : url,
+                userAlerted   : userAlerted,
         ]
     }
 

--- a/grails-app/domain/io/xh/hoist/track/TrackLog.groovy
+++ b/grails-app/domain/io/xh/hoist/track/TrackLog.groovy
@@ -17,7 +17,6 @@ class TrackLog implements JSONFormat {
     String username
     String category
     String msg
-    String error
     String browser
     String device
     String userAgent
@@ -27,7 +26,6 @@ class TrackLog implements JSONFormat {
     String url
     Integer elapsed
     String severity
-    boolean userAlerted = false
     Date dateCreated
     String impersonating
 
@@ -39,10 +37,9 @@ class TrackLog implements JSONFormat {
     }
 
     static constraints = {
-        msg(maxSize: 255, nullable: true)
+        msg(maxSize: 255)
         username(maxSize: 50)
         category(maxSize: 100)
-        error(nullable: true)
         browser(nullable: true, maxSize: 100)
         device(nullable: true, maxSize: 100)
         userAgent(nullable: true)
@@ -70,11 +67,9 @@ class TrackLog implements JSONFormat {
                 elapsed: elapsed,
                 severity: severity,
                 impersonating: impersonating,
-                error         : error,
                 appVersion    : appVersion,
                 appEnvironment: appEnvironment,
                 url           : url,
-                userAlerted   : userAlerted,
         ]
     }
 

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorAdminService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorAdminService.groovy
@@ -1,0 +1,10 @@
+package io.xh.hoist.clienterror
+
+import io.xh.hoist.BaseService
+
+class ClientErrorAdminService extends BaseService {
+
+    def queryClientError() {
+        
+    }
+}

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorAdminService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorAdminService.groovy
@@ -1,10 +1,48 @@
 package io.xh.hoist.clienterror
 
+import grails.gorm.transactions.ReadOnly
 import io.xh.hoist.BaseService
+import io.xh.hoist.data.filter.Filter
+import io.xh.hoist.track.TrackLog
+import org.hibernate.Criteria
+import org.hibernate.SessionFactory
+
+import java.time.LocalDate
+
+import static io.xh.hoist.util.DateTimeUtils.appEndOfDay
+import static io.xh.hoist.util.DateTimeUtils.appStartOfDay
+import static org.hibernate.criterion.Order.desc
+import static org.hibernate.criterion.Restrictions.between
 
 class ClientErrorAdminService extends BaseService {
+    SessionFactory sessionFactory
 
-    def queryClientError() {
-        
+    @ReadOnly
+    List<ClientError> queryClientError(LocalDate startDay, LocalDate endDay, Filter filter, int maxRows) {
+        def session = sessionFactory.currentSession
+        Criteria c = session.createCriteria(ClientError)
+        c.maxResults = maxRows
+        c.addOrder(desc('dateCreated'))
+        c.add(between('dateCreated', appStartOfDay(startDay), appEndOfDay(endDay)))
+        if (filter) {
+            c.add(filter.criterion)
+        }
+        c.list() as List<ClientError>
+    }
+
+    @ReadOnly
+    Map lookups() {[
+        browser: distinctVals('browser'),
+        device: distinctVals('device'),
+        username: distinctVals('username')
+    ] }
+
+    //------------------------
+    // Implementation
+    //------------------------
+    private List distinctVals(String property) {
+        TrackLog.createCriteria().list {
+            projections { distinct(property) }
+        }.sort()
     }
 }

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorAdminService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorAdminService.groovy
@@ -34,14 +34,15 @@ class ClientErrorAdminService extends BaseService {
     Map lookups() {[
         browser: distinctVals('browser'),
         device: distinctVals('device'),
-        username: distinctVals('username')
+        username: distinctVals('username'),
+        appEnvironment: distinctVals('appEnvironment')
     ] }
 
     //------------------------
     // Implementation
     //------------------------
     private List distinctVals(String property) {
-        TrackLog.createCriteria().list {
+        ClientError.createCriteria().list {
             projections { distinct(property) }
         }.sort()
     }

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -111,8 +111,8 @@ class TrackService extends BaseService implements EventPublisher {
             elapsed: params.elapsed,
             severity: params.severity ?: 'INFO',
             data: data,
-            url: params.url? params.url: null,
-            appVersion: params.appVersion ? params.appVersion: null,
+            url: params.url,
+            appVersion: params.appVersion ?: Utils.appVersion,
             appEnvironment: Utils.appEnvironment
         ]
 

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -11,6 +11,7 @@ import grails.events.EventPublisher
 import groovy.transform.CompileStatic
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.ConfigService
+import io.xh.hoist.util.Utils
 
 import static io.xh.hoist.browser.Utils.getBrowser
 import static io.xh.hoist.browser.Utils.getDevice
@@ -109,7 +110,10 @@ class TrackService extends BaseService implements EventPublisher {
             device: getDevice(userAgent),
             elapsed: params.elapsed,
             severity: params.severity ?: 'INFO',
-            data: data
+            data: data,
+            url: params.url? params.url: null,
+            appVersion: params.appVersion ? params.appVersion: null,
+            appEnvironment: Utils.appEnvironment
         ]
 
         // Execute asynchronously after we get info from request, don't block application thread.


### PR DESCRIPTION
This PR adds new fields to TrackLog and ClientError databases to consolidate the two (to the extent that it makes sense)

It also refactors the `XhController` endpoints for `track` and `submitError` to expect the input parameters to be posted as JSON to the request body. One note about this change, because of the current implementation of the `ensureClientUsernameMatchesSession` method, `clientUsername` still needs to be posted to the server as a `param`. 

Finally, this server-side change refactors the `ClientErrorAdminController` to use a new service, the `ClientErrorAdminService`, to use filters provided by the client to do server-side filtering (this pattern is used in `TrackLogAdminController` and `TrackLogAdminService`).