### PR TITLE
Code cleanups and smaller refactors to monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Please contact XH to review your app's readiness for multi-instance operation!
 ### 💥 Breaking Changes (upgrade difficulty: 🟠 MEDIUM / 🟢 LOW for apps with minimal custom server-side functionality)
 
 * Requires `hoist-react >= 64.0` for essential Admin Console upgrades.
-* Requires updated `gradle.properties` to specify `hazelcast.version=5.x.x`. Check hoist-core or
+* Requires updated `gradle.properties` to specify `hazelcast.version=5.3.x`. Check hoist-core or
   Toolbox at time of upgrade to confirm exact recommended version.
 * Requires column additions to three `xh_` tables with the following SQL or equivalent:
     ```sql

--- a/grails-app/services/io/xh/hoist/monitor/MonitorEvalService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorEvalService.groovy
@@ -111,11 +111,13 @@ class MonitorEvalService extends BaseService {
 
         if (type == 'None') return
 
-        if (metric == null) {
+        if (!(metric instanceof Number)) {
             result.status = FAIL
-            result.prependMessage("Monitor failed to compute metric")
+            result.prependMessage('Monitor failed to compute numerical metric.')
             return
         }
+
+        Number metricNum = metric
 
         def isCeil = (type == 'Ceil'),
             sign = isCeil ? 1 : -1,
@@ -125,10 +127,10 @@ class MonitorEvalService extends BaseService {
             currSeverity = result.status.severity,
             units = monitor.metricUnit ?: ''
 
-        if (fail != null && (metric - fail) * sign > 0 && currSeverity < FAIL.severity) {
+        if (fail != null && (metricNum - fail) * sign > 0 && currSeverity < FAIL.severity) {
             result.status = FAIL
             result.prependMessage("Metric value is $verb failure limit of $fail $units")
-        } else if (warn != null && (metric - warn) * sign > 0 && currSeverity < WARN.severity) {
+        } else if (warn != null && (metricNum - warn) * sign > 0 && currSeverity < WARN.severity) {
             result.status = WARN
             result.prependMessage("Metric value is $verb warn limit of $warn $units")
         }

--- a/src/main/groovy/io/xh/hoist/monitor/MonitorConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/monitor/MonitorConfig.groovy
@@ -1,0 +1,17 @@
+package io.xh.hoist.monitor
+
+import groovy.transform.MapConstructor
+
+/**
+ * Typed representation of `xhMonitorConfig` values.
+ */
+@MapConstructor
+class MonitorConfig {
+    Integer monitorRefreshMins
+    Integer monitorStartupDelayMins
+    Integer monitorRepeatNotifyMins
+    Integer failNotifyThreshold
+    Integer warnNotifyThreshold
+    Integer monitorTimeoutSecs
+    Boolean writeToMonitorLog
+}

--- a/src/main/groovy/io/xh/hoist/monitor/MonitorResult.groovy
+++ b/src/main/groovy/io/xh/hoist/monitor/MonitorResult.groovy
@@ -13,12 +13,18 @@ import io.xh.hoist.json.JSONParser
 
 import static io.xh.hoist.monitor.MonitorStatus.UNKNOWN
 
+/**
+ * Results from the run of a single monitor on a single instance.
+ *
+ * An instance of this object is passed into each app-level monitor implementation within
+ * `MonitorDefinitionService` and is used to collect and return the results of each check.
+ */
 @CompileStatic
 class MonitorResult implements JSONFormat {
     String instance
     Boolean primary
     MonitorStatus status = UNKNOWN
-    Object metric
+    Number metric
     String message
     Long elapsed
     Date date

--- a/src/main/groovy/io/xh/hoist/monitor/MonitorResult.groovy
+++ b/src/main/groovy/io/xh/hoist/monitor/MonitorResult.groovy
@@ -24,7 +24,7 @@ class MonitorResult implements JSONFormat {
     String instance
     Boolean primary
     MonitorStatus status = UNKNOWN
-    Number metric
+    Object metric
     String message
     Long elapsed
     Date date

--- a/src/main/groovy/io/xh/hoist/monitor/MonitorStatusReport.groovy
+++ b/src/main/groovy/io/xh/hoist/monitor/MonitorStatusReport.groovy
@@ -11,15 +11,31 @@ import io.xh.hoist.util.Utils
 
 import static io.xh.hoist.monitor.MonitorStatus.*
 
+/**
+ * Consolidated report of results across all available AggregateMonitorResults, with a single
+ * roll-up status and generated title.
+ */
 class MonitorStatusReport {
     final MonitorStatus status
     final String title
-    final List<MonitorResults> results
+    final List<AggregateMonitorResult> results
 
-    MonitorStatusReport(List<MonitorResults> results) {
+    MonitorStatusReport(List<AggregateMonitorResult> results) {
         this.results = results
         status = results ? results.max { it.status }.status : OK
         title = computeTitle()
+    }
+
+    String toHtml() {
+        def problems = results.findAll {it.status >= WARN}
+        if (!problems) return "There are no alerting monitors for ${Utils.appName}."
+
+        return problems
+            .sort {it.name}
+            .sort {it.status }
+            .collect {
+                "+ ${it.name} | ${it.message ? it.message + ' | ' : ''}Minutes in [${it.status}]: ${it.minsInStatus}"
+            }.join('<br>')
     }
 
     private String computeTitle() {


### PR DESCRIPTION
+ Type `MonitorResult.metric` as `Number`
+ Rename MonitorsResults -> AggregateMonitorResult for clarity
+ New MonitorConfig class to formalize expected definition and types of required Hoist appConfig.
+ Apply `@GrailsCompileStatic` to services.
+ Additional doc comments.