### PR TITLE
Fixed DefaultRoleService completely failing if presented with a bad roleMember

### DIFF
--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -346,8 +346,12 @@ class DefaultRoleService extends BaseRoleService {
                 if (!visitedRoles.contains(it)) {
                     visitedRoles << it
                     def effectiveRole = Role.get(it)
-                    rolesToVisit << effectiveRole
-                    ret << effectiveRole
+                    if (effectiveRole) {
+                        rolesToVisit << effectiveRole
+                        ret << effectiveRole
+                    } else {
+                        logWarn("Role ${role.name} references non-existent role $it", "skipping")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently, if a roleMember is present with roleMember.type==ROLE and an invalid/missing roleMember.name (one that does not match the Role.name of any Role), the DefaultRoleService will completely crash/fail, locking everyone out of the application.

This doesn't ever happen in normal operations/using the roles UI, but may happen if an application is manually changing roles/roleMembers (ie, migrating roles).