### PR TITLE
Fixed BaseService.initialize() hiding stack trace for init exceptions

### DIFF
--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -88,14 +88,14 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
         if (initializedDate) return
         try {
             withInfo("Initializing") {
-                def p = task { init() }
+                def p = task {
+                    init()
+                }
                 p.onError { Throwable t ->
                     // This copy of the exception includes the stack trace into `init()`.
                     xhExceptionHandler.handleException(exception: t, logTo: this)
                 }
-                try {
-                    p.get(timeout, TimeUnit.MILLISECONDS)
-                } catch (Throwable ignored)
+                p.get(timeout, TimeUnit.MILLISECONDS)
                 setupClearCachesConfigs()
             }
         } catch (Throwable t) {

--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -88,15 +88,14 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
         if (initializedDate) return
         try {
             withInfo("Initializing") {
-                task {
-                    init()
-                }.get(timeout, TimeUnit.MILLISECONDS)
+                // Uses Promises.waitAll() to emit any exception thrown during the init task.
+                Promises.waitAll([task { init() }], timeout, TimeUnit.MILLISECONDS)
                 setupClearCachesConfigs()
             }
         } catch (Throwable t) {
             xhExceptionHandler.handleException(exception: t, logTo: this)
         } finally {
-            initializedDate = new Date();
+            initializedDate = new Date()
         }
     }
 


### PR DESCRIPTION
I have noticed that exceptions thrown by implementations of `BaseService.init()` using the `BaseService.parallelInit()` method do not show their full stack trace. This was because we were cutting off the exception "history" in `BaseService.initialize()`.

