### PR TITLE
Fixed `defaultRoleService.list()` failing if presented with a bad roleMember

### DIFF
--- a/grails-app/services/io/xh/hoist/role/provided/DefaultRoleAdminService.groovy
+++ b/grails-app/services/io/xh/hoist/role/provided/DefaultRoleAdminService.groovy
@@ -39,7 +39,7 @@ class DefaultRoleAdminService extends BaseService {
             errorsForGroups = emptyMap()
 
         if (defaultRoleService.directoryGroupsSupported) {
-            Set<String> groups = roles.collectMany(new HashSet()) { it.directoryGroups }
+            Set<String> groups = roles.collectMany(new HashSet()) { it?.directoryGroups }
             if (groups) {
                 try {
                     Map<String, Object> groupsLookup = defaultRoleService.loadUsersForDirectoryGroups(groups, true)
@@ -56,8 +56,8 @@ class DefaultRoleAdminService extends BaseService {
         roles.collect {role ->
             def inheritedRoles = getInheritedRoles(role),
                 effectiveRoles = getEffectiveRoles(role),
-                effectiveGroups = getEffectiveMembers(role, effectiveRoles) { it.directoryGroups },
-                effectiveAssignedUsers = getEffectiveMembers(role, effectiveRoles) { it.users },
+                effectiveGroups = getEffectiveMembers(role, effectiveRoles) { it?.directoryGroups },
+                effectiveAssignedUsers = getEffectiveMembers(role, effectiveRoles) { it?.users },
                 effectiveUsers = getEffectiveUsers(effectiveAssignedUsers, effectiveGroups, usersForGroups),
                 effectiveGroupNames = effectiveGroups*.name.toSet()
             [


### PR DESCRIPTION
Currently, if you attempt to access the roles page in an environment where there is a "bad roleMember", the `defaultRoleService.list()` fails with the message: `Cannot get property 'directoryGroups' on null object.`

Follow-up to https://github.com/xh/hoist-core/pull/357