### PR TITLE
BaseUserService now allows app implementation to use the app's User type

### DIFF
--- a/src/main/groovy/io/xh/hoist/user/BaseUserService.groovy
+++ b/src/main/groovy/io/xh/hoist/user/BaseUserService.groovy
@@ -29,7 +29,7 @@ abstract class BaseUserService extends BaseService {
      * Return all users,
      * @param activeOnly - true to return "active" users only.
      */
-    abstract List<HoistUser> list(boolean activeOnly)
+    abstract List<? extends HoistUser> list(boolean activeOnly)
 
     /**
      * Return the users that a given user can impersonate.
@@ -40,7 +40,7 @@ abstract class BaseUserService extends BaseService {
      * Overrides are highly encouraged to call this super implementation as an initial filter
      * and skip doing so at their own risk.
      */
-    List<HoistUser> impersonationTargetsForUser(HoistUser authUser) {
+    List<? extends HoistUser> impersonationTargetsForUser(HoistUser authUser) {
         if (!authUser.canImpersonate) return []
         def isAdmin = authUser.isHoistAdmin
         list(true).findAll { HoistUser target ->


### PR DESCRIPTION
Currently, BaseUserService does not allow the implementation to use it's own User:
```groovy
class AppUser extends HoistUser { ... 
```
```groovy
class UserService extends BaseUserService {
    // This does not build, because the return type of `List<AppUser> ` is incompatible with `List<HoistUser>`
    @Override
    List<AppUser> list(boolean activeOnly) { ... 
```
With this fix, the app's UserService is allowed to type its own methods.