### PR TITLE
LdapService & LdapPerson Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 21.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* LdapService `searchOne` and `searchMany` methods have been made public.
+* LdapPerson class now includes `displayName`, `givenname`, and `sn` fields.
+
+### 🐞 Bug Fixes
+
+* LdapPerson class `email` key changed to `mail` to match LDAP attribute.
+
 ## 20.0.2 - 2024-06-05
 
 ### 🐞 Bug Fixes

--- a/src/main/groovy/io/xh/hoist/ldap/LdapPerson.groovy
+++ b/src/main/groovy/io/xh/hoist/ldap/LdapPerson.groovy
@@ -2,10 +2,20 @@ package io.xh.hoist.ldap
 
 import javax.management.Attribute
 
-class LdapPerson extends LdapObject{
+/**
+ * Minimal set of attributes returned by a search for objectCategory=Person in Microsoft's AD LDAP implementation.
+ * If you need more attributes, you can extend this class and add them.
+ *
+ * Available attributes can be found here:
+ * https://learn.microsoft.com/en-us/archive/technet-wiki/12037.active-directory-get-aduser-default-and-extended-properties
+ */
+class LdapPerson extends LdapObject {
 
     String name
-    String email
+    String displayname
+    String givenname
+    String sn
+    String mail
 
     static LdapPerson create(Collection<Attribute> atts) {
         def ret = new LdapPerson()
@@ -14,6 +24,6 @@ class LdapPerson extends LdapObject{
     }
 
     static List<String> getKeys() {
-        LdapObject.keys + ['name', 'email']
+        LdapObject.keys + ['name', 'displayname', 'givenname', 'sn', 'mail']
     }
 }


### PR DESCRIPTION
### 🎁 New Features

* LdapService `searchOne` and `searchMany` methods have been made public.
* LdapPerson class now includes `displayName`, `givenname`, and `sn` fields.

### 🐞 Bug Fixes

* LdapPerson class `email` key changed to `mail` to match LDAP attribute.

This branch's changes have been tested in a client app that needed these changes. 