### PR TITLE
Remove compileStatic annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Remove obsolete, non-functioning GSP support from EmailService.
 
+### 🐞 Bug Fixes
+
+* `compileStatic` annotation removed from Ldap objects.  It was preventing the `keys` call in the
+  LdapObject `populate` method from using the subclass' `getKeys` method.
+
 ## 20.2.0 - 2024-06-26
 
 ### ⚙️ Technical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@
 * Remove obsolete, non-functioning GSP support from EmailService.
 
 ### 🐞 Bug Fixes
-
-* `compileStatic` annotation removed from Ldap objects.  It was preventing the `keys` call in the
-  LdapObject `populate` method from using the subclass' `getKeys` method.
+* Fix to regression with LdapObject not fully populating all keys.
 
 ## 20.2.0 - 2024-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Remove obsolete, non-functioning GSP support from EmailService.
 
 ### 🐞 Bug Fixes
-* Fix to regression with LdapObject not fully populating all keys.
+* Fix to regression with LdapObject where it was not fully populating all of its keys/properties.
 
 ## 20.2.0 - 2024-06-26
 

--- a/src/main/groovy/io/xh/hoist/ldap/LdapGroup.groovy
+++ b/src/main/groovy/io/xh/hoist/ldap/LdapGroup.groovy
@@ -1,9 +1,7 @@
 package io.xh.hoist.ldap
 
-import groovy.transform.CompileStatic
 import org.apache.directory.api.ldap.model.entry.Attribute
 
-@CompileStatic
 class LdapGroup extends LdapObject {
 
     /** DNs of all group members (yes, the property name looks singular, but is the collection) */

--- a/src/main/groovy/io/xh/hoist/ldap/LdapObject.groovy
+++ b/src/main/groovy/io/xh/hoist/ldap/LdapObject.groovy
@@ -1,6 +1,5 @@
 package io.xh.hoist.ldap
 
-import groovy.transform.CompileStatic
 import org.apache.directory.api.ldap.model.entry.Attribute
 
 /**
@@ -12,7 +11,6 @@ import org.apache.directory.api.ldap.model.entry.Attribute
  * Available attributes can be found here:
  * https://learn.microsoft.com/en-us/archive/technet-wiki/12037.active-directory-get-aduser-default-and-extended-properties
  */
-@CompileStatic
 class LdapObject {
 
     String cn

--- a/src/main/groovy/io/xh/hoist/ldap/LdapPerson.groovy
+++ b/src/main/groovy/io/xh/hoist/ldap/LdapPerson.groovy
@@ -1,9 +1,7 @@
 package io.xh.hoist.ldap
 
-import groovy.transform.CompileStatic
 import org.apache.directory.api.ldap.model.entry.Attribute
 
-@CompileStatic
 class LdapPerson extends LdapObject {
 
     /** First name of the person */


### PR DESCRIPTION
Remove compileStatic annotation.
It was preventing the `keys` call in the LdapObject `populate` method from using the subclass' `getKeys` method.

CompileStatic was added recently in this commit https://github.com/xh/hoist-core/pull/364/commits/2c85e6ab644d95f53b91d6cd490aa76ff3cac7ad merged in this PR: https://github.com/xh/hoist-core/pull/364

The bug was found by a client using the `findGroups` method. He noticed that the `member` key on the retuned`LdapGroup` result was always `null`.  The `findGroups` method is not used in any production code, so this does not require an urgent release.

This does not affect the  `DefaultRoleService` because it uses the `lookupGroupMembers` method.