### PR TITLE
Fix configuration of Hazelcast distributed objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 21.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+* Fix a regression to the configuration of Hazelcast distributed objects and hibernate caches.
+
 ## 20.2.1 - 2024-07-09
 
 ### ⚙️ Technical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 21.0-SNAPSHOT - unreleased
 
-### 🐞 Bug Fixes
-* Fix a regression to the configuration of Hazelcast distributed objects and hibernate caches.
+### ⚙️ Technical
+* Improvements to the ability to configure Hibernate Caches for 2nd-level and connection caches.
 
 ## 20.2.1 - 2024-07-09
 

--- a/grails-app/domain/io/xh/hoist/role/provided/Role.groovy
+++ b/grails-app/domain/io/xh/hoist/role/provided/Role.groovy
@@ -33,12 +33,13 @@ class Role implements JSONFormat {
         lastUpdatedBy maxSize: 50
     }
 
+    // We don't expect a huge number of roles.
+    // Tighten as examples of custom cache and collection query size
     static cache = {
-        evictionConfig.size = 5000
+        evictionConfig.size = 1000
     }
-
     static membersCollectionCache = {
-        evictionConfig.size = 5000
+        evictionConfig.size = 1000
     }
 
     static beforeInsert = {

--- a/grails-app/domain/io/xh/hoist/role/provided/Role.groovy
+++ b/grails-app/domain/io/xh/hoist/role/provided/Role.groovy
@@ -34,11 +34,8 @@ class Role implements JSONFormat {
     }
 
     // We don't expect a huge number of roles.
-    // Tighten as examples of custom cache and collection query size
+    // Tighten as example of a custom cache config being applied to a collection cache (Role.members)
     static cache = {
-        evictionConfig.size = 1000
-    }
-    static membersCollectionCache = {
         evictionConfig.size = 1000
     }
 

--- a/grails-app/domain/io/xh/hoist/role/provided/Role.groovy
+++ b/grails-app/domain/io/xh/hoist/role/provided/Role.groovy
@@ -33,6 +33,14 @@ class Role implements JSONFormat {
         lastUpdatedBy maxSize: 50
     }
 
+    static cache = {
+        evictionConfig.size = 5000
+    }
+
+    static membersCollectionCache = {
+        evictionConfig.size = 5000
+    }
+
     static beforeInsert = {
         if (Role.findByNameIlike(name)) {
             throw new RoutineRuntimeException('Role Name must be case-insensitive unique.')

--- a/grails-app/init/io/xh/hoist/ClusterConfig.groovy
+++ b/grails-app/init/io/xh/hoist/ClusterConfig.groovy
@@ -168,7 +168,7 @@ class ClusterConfig {
                 // workaround - hz does not clone evictionConfig
                 baseConfig.evictionConfig = new EvictionConfig(baseConfig.evictionConfig)
                 customizer.delegate = baseConfig
-                customizer.resolveStrategy = DELEGATE_FIRST
+                customizer.resolveStrategy = Closure.DELEGATE_FIRST
                 customizer(baseConfig)
             }
         }
@@ -198,7 +198,7 @@ class ClusterConfig {
                         throw new RuntimeException('Unable to configure Cluster object')
                 }
                 customizer.delegate = objConfig
-                customizer.resolveStrategy = DELEGATE_FIRST
+                customizer.resolveStrategy = Closure.DELEGATE_FIRST
                 customizer(objConfig)
             }
         }


### PR DESCRIPTION
Should be a simplification and more straightforward use of the hazelcast config API.  The get methods already do clone the current configuration and "add" a new configuration.  I think we may have been thrown off with a very specific bug around the failure to deep clone evictionConfig