### PR TITLE
Simplified the xhDbConnectionMonitor query to work with more SQL dialects

### DIFF
--- a/src/main/groovy/io/xh/hoist/monitor/provided/DefaultMonitorDefinitionService.groovy
+++ b/src/main/groovy/io/xh/hoist/monitor/provided/DefaultMonitorDefinitionService.groovy
@@ -116,7 +116,7 @@ class DefaultMonitorDefinitionService extends BaseService {
         def startTime = currentTimeMillis()
         Sql sql = new Sql(dataSource)
         try {
-            sql.rows("SELECT * FROM xh_monitor WHERE code = 'xhDbConnectionMonitor' LIMIT 1")
+            sql.rows("SELECT * FROM xh_monitor WHERE code = 'xhDbConnectionMonitor'")
         } finally {
             sql.close()
         }


### PR DESCRIPTION
The existing query, `SELECT * FROM xh_monitor WHERE code = 'xhDbConnectionMonitor' LIMIT 1`, does not work in SQL Server (Microsoft SQL).
The equivalent statement in SQL Server would be `SELECT TOP(1) * FROM xh_monitor WHERE code = 'xhDbConnectionMonitor'`

I propose we simplify it to the SQL statement `SELECT * FROM xh_monitor WHERE code = 'xhDbConnectionMonitor'`, which should work in all dialects.