### PR TITLE
Clarify `EnvironmentService` handling of invalid `xhAppTimeZone` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## 21.0-SNAPSHOT - unreleased
 
-### 🐞 Bug Fixes
-
-* Fix in `EnvironmentService` to show error log when passed in an invalid time zone ID by setting to
-  default time zone after the check.
-
 ## 20.4.0 - 2024-07-31
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 21.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fix in `EnvironmentService` to show error log when passed in an invalid time zone ID by setting to
+  default time zone after the check.
+
 ## 20.4.0 - 2024-07-31
 
 ### 🐞 Bug Fixes

--- a/grails-app/services/io/xh/hoist/environment/EnvironmentService.groovy
+++ b/grails-app/services/io/xh/hoist/environment/EnvironmentService.groovy
@@ -89,10 +89,11 @@ class EnvironmentService extends BaseService {
     //---------------------
     private TimeZone calcAppTimeZone() {
         def defaultZone = 'UTC',
-            configZoneId = configService.getString('xhAppTimeZone', defaultZone)
+            configZoneId = configService.getString('xhAppTimeZone')
 
         if (!TimeZone.availableIDs.contains(configZoneId)) {
             log.error("Invalid xhAppTimeZone config: '$configZoneId' not a valid ZoneId - will fall back to $defaultZone.")
+            configZoneId = defaultZone;
         }
 
         return TimeZone.getTimeZone(configZoneId)


### PR DESCRIPTION
Fixes the issue where the log would never call because `configZoneId` given a bad `xhAppTimeZone` value would return the `defaultZone`. This would then be considered valid as an available ID by the conditional and therefore not log if we use the default or not.