### PR TITLE
`CachedValue.timestamp` + minor `DateTimeUtils` updates

### DIFF
--- a/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
@@ -42,7 +42,7 @@ class CachedValue<V> extends BaseCache<V> {
         }
     }
 
-    /** Get the value. */
+    /** @returns the cached value. */
     V get() {
         def ret = _map[name]
         if (ret && shouldExpire(ret)) {
@@ -50,6 +50,16 @@ class CachedValue<V> extends BaseCache<V> {
             return null
         }
         return ret?.value
+    }
+
+    /** @returns the cached value, or calls the provided closure to create, cache, and return. */
+    V getOrCreate(Closure<V> c) {
+        V ret = get()
+        if (ret == null) {
+            ret = c()
+            set(ret)
+        }
+        return ret
     }
 
     /** Set the value. */
@@ -65,24 +75,18 @@ class CachedValue<V> extends BaseCache<V> {
         if (!useCluster) fireOnChange(name, oldEntry?.value, value)
     }
 
-    /** Return the cached value, or lazily create if needed. */
-    V getOrCreate(Closure<V> c) {
-        V ret = get()
-        if (ret == null) {
-            ret = c()
-            set(ret)
-        }
-        return ret
-    }
-
-    /** Clear value. */
+    /** Clear the value. */
     void clear() {
         set(null)
     }
 
+    /** @returns timestamp of the current entry, or null if none. */
+    Long getTimestamp() {
+        getEntryTimestamp(_map[name])
+    }
+
     /**
-     * Wait for the replicated value to be populated
-     *
+     * Wait for the replicated value to be populated.
      * @param timeout, time in ms to wait.  -1 to wait indefinitely (not recommended).
      * @param interval, time in ms to wait between tests.
      * @param timeoutMessage, custom message associated with any timeout.

--- a/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/DateTimeUtils.groovy
@@ -9,10 +9,12 @@ package io.xh.hoist.util
 
 import groovy.transform.CompileStatic
 
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 
+import static java.lang.System.currentTimeMillis
 import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE
 
 @CompileStatic
@@ -34,10 +36,36 @@ class DateTimeUtils {
     static final String TIME_FMT = 'h:mma'
     static final String MONTH_DAY_FMT = 'MMM d'
 
-    static boolean intervalElapsed(Long interval, Object lastRun) {
-        if (!lastRun) return true
-        Long lastRunMs = lastRun instanceof Date ? ((Date) lastRun).time : (Long) lastRun
-        return System.currentTimeMillis() > lastRunMs + interval
+    /**
+     * @param intervalInMs
+     * @param startTimestamp to compare against, as Date, Instant, or Long.
+     * @returns true if at least intervalInMs has elapsed since startTimestamp.
+     */
+    static boolean intervalElapsed(Long intervalInMs, Object startTimestamp) {
+        if (startTimestamp == null) return true
+        Long startMs = asEpochMilli(startTimestamp)
+        return currentTimeMillis() > (startMs + intervalInMs)
+    }
+
+    /**
+     * @param timestamp to convert, as Date, Instant, or Long (to be returned as-is)
+     * @returns timestamp as epoch milliseconds, or null if timestamp is null.
+     */
+    static Long asEpochMilli(Object timestamp) {
+        if (timestamp == null) return null
+        if (timestamp instanceof Date) return ((Date) timestamp).time
+        if (timestamp instanceof Instant) return ((Instant) timestamp).toEpochMilli()
+        if (timestamp instanceof Long) return (Long) timestamp
+        throw new IllegalArgumentException("Invalid timestamp: ${timestamp}")
+    }
+
+    /**
+     * @param dateString in 'YYYYMMDD' or 'YYYY-MM-DD' format.
+     * @returns parsed LocalDate, or null if dateString is null.
+     */
+    static LocalDate parseLocalDate(String dateString) {
+        if (!dateString) return null
+        return LocalDate.parse(dateString.replace('-', ''), BASIC_ISO_DATE)
     }
 
     static TimeZone getAppTimeZone() {
@@ -80,12 +108,4 @@ class DateTimeUtils {
         Date.from(localDate.atTime(LocalTime.MAX).atZone(serverZoneId).toInstant())
     }
 
-    /**
-     * Parse a local date
-     * @param s - Valid date in 'YYYYMMDD' or 'YYYY-MM-DD' format.
-     */
-    static LocalDate parseLocalDate(String s) {
-        if (!s) return null
-        return LocalDate.parse(s.replace('-', ''), BASIC_ISO_DATE)
-    }
 }


### PR DESCRIPTION
+ Was looking for equiv of `Cache.getEntry(k).dateEntered`.
+ Although this new getter and new `Cache.getTimestamp(k)` respect optional `timestampFn`.
+ New `DateTimeUtils.toEpochMilli()`.
+ Support passing Instants to the above + existing `intervalElapsed()`.
+ Additional OCD tweaks to / standardization of docstrings.