### PR TITLE
Improvements to serialization efficiency of replicated `Cache` and `CachedValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 22.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+* Improvements to serialization efficiency of replicated `Cache` and `CachedValue`
+
 ## 21.0.0 - 2024-09-03
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - latest Hoist React + DB col additions)

--- a/src/main/groovy/io/xh/hoist/cache/HzEntryListener.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/HzEntryListener.groovy
@@ -1,0 +1,43 @@
+package io.xh.hoist.cache
+
+import com.hazelcast.core.EntryEvent
+import com.hazelcast.core.EntryListener
+import com.hazelcast.map.MapEvent
+
+class HzEntryListener implements EntryListener {
+
+    private BaseCache target
+
+    HzEntryListener(BaseCache target) {
+        this.target = target
+    }
+
+    void entryAdded(EntryEvent event) {
+        fireEvent(event)
+    }
+
+    void entryEvicted(EntryEvent event) {
+        fireEvent(event)
+    }
+
+    void entryExpired(EntryEvent event) {
+        fireEvent(event)
+    }
+
+    void entryRemoved(EntryEvent event) {
+        fireEvent(event)
+    }
+
+    void entryUpdated(EntryEvent event) {
+        fireEvent(event)
+    }
+
+    void mapCleared(MapEvent event) {}
+
+    void mapEvicted(MapEvent event) {}
+
+    private fireEvent(EntryEvent event) {
+        target.fireOnChange(event.key, event.oldValue?.value, event.value?.value)
+    }
+
+}


### PR DESCRIPTION
The hz event handler itself was triggering more serialization!  Skip it, unless we are going to do something with it.