### PR TITLE
Expose `/xh/ping` as whitelisted route for uptime/reachability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 22.0-SNAPSHOT
+
+### ⚙️ Technical
+
+* Exposed `/xh/ping` as whitelisted route for basic uptime/reachability checks. Retained legacy
+  `/ping` alias, but prefer this new path going forward.
+
 ## 21.0.1 - 2024-09-05
 
 ### 🐞 Bug Fixes

--- a/grails-app/controllers/io/xh/hoist/UrlMappings.groovy
+++ b/grails-app/controllers/io/xh/hoist/UrlMappings.groovy
@@ -18,7 +18,9 @@ class UrlMappings {
         "/$controller/$action?/$id?(.$format)?"{}
 
         "404" (controller: 'xh', action: 'notFound')
-        "/ping" (controller: 'xh', action: 'version')
+
+        // Legacy alias for /xh/ping
+        "/ping" (controller: 'xh', action: 'ping')
 
         //------------------------
         // Rest Support

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -276,16 +276,25 @@ class XhController extends BaseController {
     // Misc
     //-----------------------
     /**
+     * Whitelisted (pre-auth) endpoint with minimal app identifier, for uptime/reachability checks.
+     * Also reachable via legacy `/ping` alias (via `UrlMappings`), but prefer `/xh/ping`.
+     */
+    def ping() {
+        renderJSON(
+            appCode: Utils.appCode,
+            timestamp: System.currentTimeMillis(),
+            success: true
+        )
+    }
+
+    /**
      * Whitelisted (pre-auth) endpoint with minimal app identifier and version info.
-     * Also reachable (for backwards compatibility) via /ping, as per `UrlMappings`.
      */
     def version() {
         renderJSON(
             appCode: Utils.appCode,
             appVersion: Utils.appVersion,
             appBuild: Utils.appBuild,
-            timestamp: System.currentTimeMillis(),
-            success: true,
             // TODO - this is a temporary measure to ensure that clients running hoist-react < 67
             //      prompt for upgrade when a new app release is deployed with hoist-core >= 21.
             //      Going forward clients will read these instructions from `xh/environmentPoll`.

--- a/src/main/groovy/io/xh/hoist/security/BaseAuthenticationService.groovy
+++ b/src/main/groovy/io/xh/hoist/security/BaseAuthenticationService.groovy
@@ -147,9 +147,10 @@ abstract class BaseAuthenticationService extends BaseService {
      * session within their completeAuthentication() implementations.
      */
     protected List<String> whitelistURIs = [
-        '/ping',
+        '/ping',  // legacy alias for /xh/ping (via UrlMappings)
         '/xh/login',
         '/xh/logout',
+        '/xh/ping',
         '/xh/version',
         '/xh/authConfig'
     ]


### PR DESCRIPTION
+ `ping` now about as minimal as possible - no longer aliased to `version` so no longer reading a config.
+ Remove pre-existing `ping` properties from `version` endpoint (timestamp, success:true) - nothing has ever expected those from `version`