### PR TITLE
Enhance Timer/Cache/CachedValues API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 22.0-SNAPSHOT
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
+* All `Timer`, `Cache`, and `CachedValue` object require a 'name' property.  This property was
+previously optional in many cases, but is now required in order to support new cluster features,
+logging, and admin tools.
+
+### 🎁 New Features
+* `Cache` and `CachedValue` may now be created using a factory on `BaseService`.  This streamlined
+interface reduces boilerplate, and provides a consistent interface with `Timer`.
+
 ### ⚙️ Technical
 
 * Improvements to `Timer` to avoid extra executions when primary instance changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
 * All `Timer`, `Cache`, and `CachedValue` object require a 'name' property.  This property was
 previously optional in many cases, but is now required in order to support new cluster features,
-logging, and admin tools.
+logging, and admin tools.  The new `BaseService.resources` property now will give access to all
+resources by name, if needed and replaces `BaseService.timers`.
 
 ### 🎁 New Features
 * `Cache` and `CachedValue` may now be created using a factory on `BaseService`.  This streamlined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ⚙️ Technical
 
+* Improvements to `Timer` to avoid extra executions when primary instance changes.
+
 * Updated `ClusterService` to use Hoist's `InstanceNotFoundException` class to designate routine.
 
 * Exposed `/xh/ping` as whitelisted route for basic uptime/reachability checks. Retained legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ previously optional in many cases, but is now required in order to support new c
 logging, and admin tools.  The new `BaseService.resources` property now will give access to all
 resources by name, if needed and replaces `BaseService.timers`.
 
+* `BaseService` methods `getIMap()`, `getReplicatedMap()` and `getISet()` have been changed to
+  `createIMap()`, `createReplicatedMap()` and `createISet()`, respectively.  This change provides
+  a consistent interface for all resources on BaseService and is not expected to impact most
+ applications.
+
 ### 🎁 New Features
-* `Cache` and `CachedValue` may now be created using a factory on `BaseService`.  This streamlined
+* `Cache` and `CachedValue` should now be created using a factory on `BaseService`.  This streamlined
 interface reduces boilerplate, and provides a consistent interface with `Timer`.
 
 ### ⚙️ Technical

--- a/grails-app/services/io/xh/hoist/admin/ConnectionPoolMonitoringService.groovy
+++ b/grails-app/services/io/xh/hoist/admin/ConnectionPoolMonitoringService.groovy
@@ -35,8 +35,9 @@ class ConnectionPoolMonitoringService extends BaseService {
 
     void init() {
         createTimer(
-            interval: {enabled ? config.snapshotInterval * DateTimeUtils.SECONDS: -1},
-            runFn: this.&takeSnapshot
+            name: 'takeSnapshot',
+            runFn: this.&takeSnapshot,
+            interval: {enabled ? config.snapshotInterval * DateTimeUtils.SECONDS: -1}
         )
     }
 

--- a/grails-app/services/io/xh/hoist/admin/MemoryMonitoringService.groovy
+++ b/grails-app/services/io/xh/hoist/admin/MemoryMonitoringService.groovy
@@ -33,8 +33,9 @@ class MemoryMonitoringService extends BaseService {
 
     void init() {
         createTimer(
-            interval: {this.enabled ? config.snapshotInterval * DateTimeUtils.SECONDS: -1},
-            runFn: this.&takeSnapshot
+            name: 'takeSnapshot',
+            runFn: this.&takeSnapshot,
+            interval: {this.enabled ? config.snapshotInterval * DateTimeUtils.SECONDS: -1}
         )
     }
 

--- a/grails-app/services/io/xh/hoist/admin/MemoryMonitoringService.groovy
+++ b/grails-app/services/io/xh/hoist/admin/MemoryMonitoringService.groovy
@@ -179,6 +179,6 @@ class MemoryMonitoringService extends BaseService {
 
     Map getAdminStats() {[
         config: configForAdminStats('xhMemoryMonitoringConfig'),
-        latestSnapshot: latestSnapshot,
+        latestSnapshot: latestSnapshot
     ]}
 }

--- a/grails-app/services/io/xh/hoist/alertbanner/AlertBannerService.groovy
+++ b/grails-app/services/io/xh/hoist/alertbanner/AlertBannerService.groovy
@@ -51,6 +51,7 @@ class AlertBannerService extends BaseService {
 
     void init() {
         timer = createTimer(
+            name: 'readFromSpec',
             interval: 2 * MINUTES,
             runFn: this.&readFromSpec,
             primaryOnly: true

--- a/grails-app/services/io/xh/hoist/alertbanner/AlertBannerService.groovy
+++ b/grails-app/services/io/xh/hoist/alertbanner/AlertBannerService.groovy
@@ -42,18 +42,14 @@ class AlertBannerService extends BaseService {
     private final static String presetsBlobName = 'xhAlertBannerPresets'
 
     private final Map emptyAlert = [active: false]
-    private CachedValue<Map> _alertBanner = new CachedValue<>(
-        name: 'alertBanner',
-        replicate: true,
-        svc: this
-    )
+    private CachedValue<Map> _alertBanner = createCachedValue(name: 'alertBanner', replicate: true)
     private Timer timer
 
     void init() {
         timer = createTimer(
             name: 'readFromSpec',
-            interval: 2 * MINUTES,
             runFn: this.&readFromSpec,
+            interval: 2 * MINUTES,
             primaryOnly: true
         )
         super.init()

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
@@ -41,7 +41,7 @@ class ClientErrorService extends BaseService {
         }]
     ]
 
-    private IMap<String, Map> errors = getIMap('clientErrors')
+    private IMap<String, Map> errors = createIMap('clientErrors')
     private int getMaxErrors()      {configService.getMap('xhClientErrorConfig').maxErrors as int}
     private int getAlertInterval()  {configService.getMap('xhClientErrorConfig').intervalMins * MINUTES}
 

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
@@ -49,6 +49,7 @@ class ClientErrorService extends BaseService {
         super.init()
         createTimer(
             name: 'processErrors',
+            runFn: this.&processErrors,
             interval: { alertInterval },
             delay: 15 * SECONDS,
             primaryOnly: true
@@ -100,7 +101,7 @@ class ClientErrorService extends BaseService {
     // Implementation
     //---------------------------------------------------------
     @Transactional
-    void onTimer() {
+    private void processErrors() {
         if (!errors) return
 
         def maxErrors = getMaxErrors(),

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
@@ -123,8 +123,7 @@ class ClientErrorService extends BaseService {
     }
 
     Map getAdminStats() {[
-        config: configForAdminStats('xhClientErrorConfig'),
-        pendingErrorCount: errors.size()
+        config: configForAdminStats('xhClientErrorConfig')
     ]}
 
 }

--- a/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
+++ b/grails-app/services/io/xh/hoist/clienterror/ClientErrorService.groovy
@@ -48,6 +48,7 @@ class ClientErrorService extends BaseService {
     void init() {
         super.init()
         createTimer(
+            name: 'processErrors',
             interval: { alertInterval },
             delay: 15 * SECONDS,
             primaryOnly: true

--- a/grails-app/services/io/xh/hoist/config/ConfigService.groovy
+++ b/grails-app/services/io/xh/hoist/config/ConfigService.groovy
@@ -207,8 +207,7 @@ class ConfigService extends BaseService {
     }
 
     void fireConfigChanged(AppConfig obj) {
-        def topic = clusterService.getTopic('xhConfigChanged')
-        topic.publishAsync([key: obj.name, value: obj.externalValue()])
+        getTopic('xhConfigChanged').publishAsync([key: obj.name, value: obj.externalValue()])
     }
 
     //-------------------

--- a/grails-app/services/io/xh/hoist/feedback/FeedbackEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/feedback/FeedbackEmailService.groovy
@@ -16,7 +16,6 @@ class FeedbackEmailService extends BaseService {
 
     void init() {
         subscribeToTopic(
-            name: 'emailFeedback',
             topic: 'xhFeedbackReceived',
             onMessage: this.&emailFeedback,
             primaryOnly: true

--- a/grails-app/services/io/xh/hoist/feedback/FeedbackEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/feedback/FeedbackEmailService.groovy
@@ -16,6 +16,7 @@ class FeedbackEmailService extends BaseService {
 
     void init() {
         subscribeToTopic(
+            name: 'emailFeedback',
             topic: 'xhFeedbackReceived',
             onMessage: this.&emailFeedback,
             primaryOnly: true

--- a/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
+++ b/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
@@ -41,9 +41,9 @@ class LdapService extends BaseService {
 
     def configService
 
-    private Cache<String, List<LdapObject>> cache = new Cache<>(
-        expireTime: {config.cacheExpireSecs * SECONDS},
-        svc: this
+    private Cache<String, List<LdapObject>> cache = createCache(
+        name: 'queryCache',
+        expireTime: {config.cacheExpireSecs * SECONDS}
     )
 
     static clearCachesConfigs = ['xhLdapConfig', 'xhLdapUsername', 'xhLdapPassword']

--- a/grails-app/services/io/xh/hoist/log/LogArchiveService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogArchiveService.groovy
@@ -27,7 +27,11 @@ class LogArchiveService extends BaseService {
         logReaderService
 
     void init() {
-        createTimer(interval: 1 * DAYS)
+        createTimer(
+            name: 'archiveLogs',
+            runFn: { archiveLogs((Integer) config.archiveAfterDays)},
+            interval: 1 * DAYS
+        )
     }
 
     List<String> archiveLogs(Integer daysThreshold) {
@@ -69,12 +73,6 @@ class LogArchiveService extends BaseService {
     //------------------------
     // Implementation
     //------------------------
-    private void onTimer() {
-        if (isPrimary) {
-            archiveLogs((Integer) config.archiveAfterDays)
-        }
-    }
-
     private File getArchiveDir(String logPath, String category) {
         return new File(logPath + separator + config.archiveFolder + separator + category)
     }

--- a/grails-app/services/io/xh/hoist/log/LogLevelService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogLevelService.groovy
@@ -23,11 +23,12 @@ class LogLevelService extends BaseService {
     private List<LogLevelAdjustment> adjustments = []
 
     void init() {
-        createTimer(interval: 30 * MINUTES, runImmediatelyAndBlock: true)
-    }
-
-    private void onTimer() {
-        calculateAdjustments()
+        createTimer(
+            name: 'calculateAdjustments',
+            runFn: this.&calculateAdjustments,
+            interval: 30 * MINUTES,
+            runImmediatelyAndBlock: true
+        )
     }
 
     // -------------------------------------------------------------------------------

--- a/grails-app/services/io/xh/hoist/monitor/MonitorService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorService.groovy
@@ -51,6 +51,7 @@ class MonitorService extends BaseService {
 
     void init() {
         timer = createTimer(
+            name: 'runMonitors',
             interval: { monitorInterval },
             delay: startupDelay,
             primaryOnly: true

--- a/grails-app/services/io/xh/hoist/monitor/MonitorService.groovy
+++ b/grails-app/services/io/xh/hoist/monitor/MonitorService.groovy
@@ -41,10 +41,9 @@ class MonitorService extends BaseService {
 
     // Shared state for all servers to read - gathered by primary from all instances.
     // Map of monitor code to aggregated (cross-instance) results.
-    private CachedValue<Map<String, AggregateMonitorResult>> _results = new CachedValue<>(
+    private CachedValue<Map<String, AggregateMonitorResult>> _results = createCachedValue(
         name: 'results',
-        replicate: true,
-        svc: this
+        replicate: true
     )
 
     private Timer timer
@@ -52,7 +51,8 @@ class MonitorService extends BaseService {
     void init() {
         timer = createTimer(
             name: 'runMonitors',
-            interval: { monitorInterval },
+            runFn: this.&runMonitors,
+            interval: {monitorInterval},
             delay: startupDelay,
             primaryOnly: true
         )
@@ -87,7 +87,7 @@ class MonitorService extends BaseService {
     //------------------
     // Implementation
     //------------------
-    private void onTimer() {
+    private void runMonitors() {
         // Gather per-instance results from across the cluster
         Map<String, List<MonitorResult>> newChecks = clusterService
             .submitToAllInstances(new RunAllMonitorsTask())

--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -392,13 +392,24 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
         resourceNames << name
     }
 
+    /** @internal - for use by Cache */
+    Map getCacheReplicatedMap(String name) {
+        ClusterService.hzInstance.getReplicatedMap(hzName(name))
+    }
+
     /** @internal - for use by CachedValue */
     Map getReplicatedCachedValuesMap() {
-        _replicatedCachedValues ?= getReplicatedMap('cachedValues')
+        if (_replicatedCachedValues == null) {
+            _replicatedCachedValues = getReplicatedMap('cachedValues')
+        }
+        return _replicatedCachedValues
     }
 
     /** @internal - for use by CachedValue */
     Map getLocalCachedValuesMap() {
-        _localCachedValues ?= new ConcurrentHashMap()
+        if (_localCachedValues == null) {
+            _localCachedValues = new ConcurrentHashMap()
+        }
+        return _localCachedValues
     }
 }

--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -122,49 +122,48 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
     // Use static reference to ClusterService to allow access pre-init.
     //------------------------------------------------------------------
     /**
-     * Get a reference to a Hazelcast IMap.
+     * Create and return a reference to a Hazelcast IMap.
      *
-     * @param name - unique name relative to all Caches, Timers and Hazelcast objects
-     *      associated with this service.
+     * @param name - must be unique across all Caches, Timers and distributed Hazelcast objects
+     * associated with this service.
      */
     <K, V> IMap<K, V> getIMap(String name) {
         addResource(name, ClusterService.hzInstance.getMap(hzName(name)))
     }
 
     /**
-     * Get a reference to a Hazelcast ISet.
+     * Create and return a reference to a Hazelcast ISet.
      *
-     * @param name - unique name relative to all Caches, Timers and Hazelcast objects
-     *      associated with this service.
+     * @param name - must be unique across all Caches, Timers and distributed Hazelcast objects
+     * associated with this service.
      */
     <V> ISet<V> getISet(String name) {
         addResource(name, ClusterService.hzInstance.getSet(hzName(name)))
     }
 
     /**
-     * Get a reference to a Hazelcast Replicated Map.
+     * Create and return a reference to a Hazelcast Replicated Map.
      *
-     * @param name - unique name relative to all Caches, Timers and Hazelcast objects
-     *      associated with this service.
+     * @param name - must be unique across all Caches, Timers and distributed Hazelcast objects
+     * associated with this service.
      */
      <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
         addResource(name, ClusterService.hzInstance.getReplicatedMap(hzName(name)))
     }
 
     /**
-     * Get a reference to a Hazelcast Replicated topic.
+     * Get a reference to a Hazelcast Replicated topic, useful to publish to a cluster-wide topic.
+     * To subscribe to events fired by other services on a topic, use {@link #subscribeToTopic}.
      */
      <M> ITopic<M> getTopic(String id) {
         ClusterService.hzInstance.getTopic(id)
     }
 
     /**
-     * Create a new managed Timer bound to this service.
+     * Create a new managed {@link Timer} bound to this service.
      *
-     * Note that the provided name should be unique with respect to all
-     * Caches, Timers and Hazelcast objects associated with this service.
-     *
-     * @see Timer
+     * Note that the provided name must be unique across all Caches, Timers and distributed
+     * Hazelcast objects associated with this service.
      */
     @CompileDynamic
     @NamedVariant
@@ -194,12 +193,10 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
     }
 
     /**
-     * Create a new Cache bound to this service.
+     * Create a new {@link Cache} bound to this service.
      *
-     * Note that the provided name should be unique with respect to all
-     * Caches, Timers and Hazelcast objects associated with this service.
-     *
-     * @see Cache
+     * Note that the provided name must be unique across all Caches, Timers and distributed
+     * Hazelcast objects associated with this service.
      */
     <K, V> Cache<K, V> createCache(Map mp) {
         // Cannot use @NamedVariant, as incompatible with generics. We'll still get run-time checks.
@@ -207,12 +204,10 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
     }
 
     /**
-     * Create a new CachedValue bound to this service.
+     * Create a new {@link CachedValue} bound to this service.
      *
-     * Note that the provided name should be unique with respect to all
-     * Caches, Timers and Hazelcast objects associated with this service.
-     *
-     * @see CachedValue
+     * Note that the provided name must be unique across all Caches, Timers and distributed
+     * Hazelcast objects associated with this service.
      */
     <T> CachedValue<T> createCachedValue(Map mp) {
         // Cannot use @NamedVariant, as incompatible with generics. We'll still get run-time checks.
@@ -221,14 +216,14 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
 
 
     /**
-     * Managed Subscription to a Grails Event.
+     * Create a managed subscription to events on the instance-local Grails event bus.
      *
-     * NOTE:  Use this method to subscribe to local Grails events on the given server
-     * instance only.  To subscribe to cluster-wide topics, use 'subscribeToTopic' instead.
+     * NOTE: this method subscribes to Grails events on the current server instance only.
+     * To subscribe to cluster-wide topics, use {@link #subscribeToTopic} instead.
      *
      * This method will catch (and log) any exceptions thrown by its handler closure.
-     * This is important because the core grails EventBus.subscribe() will silently swallow
-     * exceptions, and stop processing subsequent handlers.
+     * This is important because the core Grails `EventBus.subscribe()` will silently swallow
+     * exceptions and stop processing subsequent handlers.
      *
      * This subscription also avoids firing handlers on destroyed services. This is important in a
      * hot-reloading scenario where multiple instances of singleton services may be created.
@@ -248,10 +243,11 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
 
     /**
      *
-     * Managed Subscription to a cluster topic.
+     * Create a managed subscription to a cluster topic.
      *
-     * NOTE:  Use this method to subscribe to cluster-wide topics. To subscribe to local
-     * Grails events on this instance only, use subscribe instead.
+     * NOTE: this subscribes to cluster-wide topics. To subscribe to local Grails events on this
+     * instance only, use {@link #subscribe} instead. That said, this is most likely the method you
+     * want, as most pub/sub use cases should take multi-instance operation into account.
      *
      * This method will catch (and log) any exceptions thrown by its handler closure.
      *

--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -258,12 +258,12 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
      * This subscription also avoids firing handlers on destroyed services. This is important in a
      * hot-reloading scenario where multiple instances of singleton services may be created.
      */
-    protected void subscribeToTopic(Map config) {
-        def topic = config.topic as String,
-            onMessage = config.onMessage as Closure,
-            primaryOnly = config.primaryOnly as Boolean
-
-
+    @NamedVariant
+    protected void subscribeToTopic(
+        @NamedParam(required = true) String topic,
+        @NamedParam(required = true) Closure onMessage,
+        @NamedParam Boolean primaryOnly = false
+    ) {
         getTopic(topic).addMessageListener { Message m ->
             if (destroyed || (primaryOnly && !isPrimary)) return
             try {

--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -384,7 +384,7 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
     }
 
     private void ensureUniqueResourceName(String name) {
-        if (!name || resourceNames(name)) {
+        if (!name || resourceNames.contains(name)) {
             def msg = 'Service resource requires a unique name. '
             if (name) msg += "Name `$name` already used on this service."
             throw new RuntimeException(msg)

--- a/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
@@ -55,16 +55,16 @@ abstract class BaseCache<V> {
     public final List<Closure> onChange = []
 
     BaseCache(
-        BaseService svc,
         String name,
+        BaseService svc,
         Object expireTime,
         Closure expireFn,
         Closure timestampFn,
         boolean replicate,
         boolean serializeOldValue
     ) {
-        this.svc = svc
         this.name = name
+        this.svc = svc
         this.expireTime = expireTime
         this.expireFn = expireFn
         this.timestampFn = timestampFn

--- a/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
@@ -83,6 +83,10 @@ abstract class BaseCache<V> {
         return replicate && ClusterService.multiInstanceEnabled
     }
 
+
+    /** Information about this object for admin purposes */
+    abstract Map getAdminStats()
+
     //------------------------
     // Implementation
     //------------------------

--- a/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
@@ -78,13 +78,14 @@ abstract class BaseCache<V> {
     /** Clear all values. */
     abstract void clear()
 
-    //------------------------
-    // Implementation
-    //------------------------
-    protected boolean getUseCluster() {
+    /** Is Cache to be stored on cluster? */
+    boolean getUseCluster() {
         return replicate && ClusterService.multiInstanceEnabled
     }
 
+    //------------------------
+    // Implementation
+    //------------------------
     protected void fireOnChange(Object key, V oldValue, V value) {
         def change = new CacheValueChanged(this, key, oldValue,  value)
         onChange.each { it.call(change) }

--- a/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/BaseCache.groovy
@@ -78,13 +78,12 @@ abstract class BaseCache<V> {
     /** Clear all values. */
     abstract void clear()
 
-    /** Is Cache to be stored on cluster? */
+    /** True if this Cache should be stored across the cluster (backed by a ReplicatedMap). */
     boolean getUseCluster() {
         return replicate && ClusterService.multiInstanceEnabled
     }
 
-
-    /** Information about this object for admin purposes */
+    /** Information about this object, accessible via the Hoist Admin Console. */
     abstract Map getAdminStats()
 
     //------------------------

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -51,6 +51,7 @@ class Cache<K,V> extends BaseCache<V> {
         if (onChange) addChangeHandler(onChange)
 
         timer = new Timer(
+            name: name ? "cullEntries_$name" : 'cullEntries',
             owner: svc,
             primaryOnly: replicate,
             runFn: this.&cullEntries,

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -12,8 +12,6 @@ import groovy.transform.NamedParam
 import groovy.transform.NamedVariant
 import io.xh.hoist.BaseService
 import io.xh.hoist.util.Timer
-
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeoutException
 
 import static io.xh.hoist.util.DateTimeUtils.MINUTES
@@ -48,7 +46,7 @@ class Cache<K,V> extends BaseCache<V> {
     ) {
         super(name, svc, expireTime, expireFn, timestampFn, replicate, serializeOldValue)
 
-        _map = useCluster ? svc.getCacheReplicatedMap(name) : new ConcurrentHashMap()
+        _map = svc.getMapForCache(this)
         if (onChange) addChangeHandler(onChange)
 
         timer = svc.createTimer(

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -23,12 +23,12 @@ import static java.lang.System.currentTimeMillis
  * A key-value Cache, with support for optional entry TTL and replication across a cluster.
  */
 @CompileStatic
-class Cache<K,V> extends BaseCache<V> {
+class Cache<K, V> extends BaseCache<V> {
 
     private final Map<K, Entry<V>> _map
     private final Timer cullTimer
 
-    /** @internal - do not construct directly - use {@link BaseService#createCache}. */
+    /** @internal - do not construct directly - use {@link BaseService#createCache}.  */
     @NamedVariant
     Cache(
         @NamedParam(required = true) String name,
@@ -54,12 +54,12 @@ class Cache<K,V> extends BaseCache<V> {
         )
     }
 
-    /** @returns the cached value at key. */
+    /** @returns the cached value at key.  */
     V get(K key) {
         return getEntry(key)?.value
     }
 
-    /** @returns the cached Entry at key. */
+    /** @returns the cached Entry at key.  */
     Entry<V> getEntry(K key) {
         def ret = _map[key]
         if (ret && shouldExpire(ret)) {
@@ -86,7 +86,7 @@ class Cache<K,V> extends BaseCache<V> {
         if (!useCluster) fireOnChange(this, oldEntry?.value, obj)
     }
 
-    /** @returns cached value for key, or lazily creates if needed. */
+    /** @returns cached value for key, or lazily creates if needed.  */
     V getOrCreate(K key, Closure<V> c) {
         V ret = get(key)
         if (ret == null) {
@@ -96,13 +96,13 @@ class Cache<K,V> extends BaseCache<V> {
         return ret
     }
 
-    /** @returns a Map representation of currently cached data. */
+    /** @returns a Map representation of currently cached data.  */
     Map<K, V> getMap() {
         cullEntries()
-        return (Map<K, V>) _map.collectEntries {k, v -> [k, v.value]}
+        return (Map<K, V>) _map.collectEntries { k, v -> [k, v.value] }
     }
 
-    /** @returns the timestamp of the cached Entry at key. */
+    /** @returns the timestamp of the cached Entry at key.  */
     Long getTimestamp(K key) {
         return getEntryTimestamp(_map[key])
     }
@@ -119,7 +119,7 @@ class Cache<K,V> extends BaseCache<V> {
     void clear() {
         // Remove key-wise to ensure that we get the proper removal message for each value and
         // work around exceptions with clear on replicated map.
-        _map.each { k, v -> remove(k)}
+        _map.each { k, v -> remove(k) }
     }
 
     void addChangeHandler(Closure handler) {
@@ -132,10 +132,10 @@ class Cache<K,V> extends BaseCache<V> {
 
     /**
      * Wait for the cache entry to be populated.
-     * @param key, entry to check
-     * @param timeout, time in ms to wait.  -1 to wait indefinitely (not recommended).
-     * @param interval, time in ms to wait between tests.
-     * @param timeoutMessage, custom message associated with any timeout.
+     * @param key - entry to check
+     * @param timeout - time in ms to wait.  -1 to wait indefinitely (not recommended).
+     * @param interval - time in ms to wait between tests.
+     * @param timeoutMessage - custom message associated with any timeout.
      */
     @NamedVariant
     void ensureAvailable(
@@ -156,14 +156,13 @@ class Cache<K,V> extends BaseCache<V> {
         }
     }
 
-
     Map getAdminStats() {
         [
             name           : name,
-            type           : 'Cache' + (replicate ? '(replicated)' : ''),
+            type           : 'Cache' + (replicate ? ' (replicated)' : ''),
             count          : size(),
             latestTimestamp: _map.max { it.value.dateEntered }?.value?.dateEntered,
-            lastCullTime     : cullTimer.lastRunCompleted
+            lastCullTime   : cullTimer.lastRunCompleted
         ]
     }
 

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -50,7 +50,7 @@ class Cache<K, V> extends BaseCache<V> {
             runFn: this.&cullEntries,
             interval: 15 * MINUTES,
             delay: true,
-            primaryOnly: replicate
+            primaryOnly: useCluster
         )
     }
 

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -28,11 +28,7 @@ class Cache<K,V> extends BaseCache<V> {
     private final Map<K, Entry<V>> _map
     private final Timer cullTimer
 
-    /**
-     * @internal
-     *
-     * Not typically created directly. Use BaseService.createCache() instead.
-     */
+    /** @internal - do not construct directly - use {@link BaseService#createCache}. */
     @NamedVariant
     Cache(
         @NamedParam(required = true) String name,

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -48,7 +48,7 @@ class Cache<K,V> extends BaseCache<V> {
     ) {
         super(name, svc, expireTime, expireFn, timestampFn, replicate, serializeOldValue)
 
-        _map = useCluster ? svc.getReplicatedMap(name) : new ConcurrentHashMap()
+        _map = useCluster ? svc.getCacheReplicatedMap(name) : new ConcurrentHashMap()
         if (onChange) addChangeHandler(onChange)
 
         timer = svc.createTimer(

--- a/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
@@ -19,18 +19,23 @@ class CachedValue<V> extends BaseCache<V> {
 
     private final Map<String, Entry<V>> _map
 
+    /**
+     * @internal
+     *
+     * Not typically created directly. Use BaseService.createCachedValue() instead.
+     */
     @NamedVariant
     CachedValue(
-        @NamedParam(required = true) BaseService svc,
         @NamedParam(required = true) String name,
+        @NamedParam(required = true) BaseService svc,
         @NamedParam Object expireTime = null,
         @NamedParam Closure expireFn = null,
         @NamedParam Closure timestampFn = null,
-        @NamedParam boolean replicate = false,
-        @NamedParam boolean serializeOldValue = false,
+        @NamedParam Boolean replicate = false,
+        @NamedParam Boolean serializeOldValue = false,
         @NamedParam Closure onChange = null
     ) {
-        super(svc, name, expireTime, expireFn, timestampFn, replicate, serializeOldValue)
+        super(name, svc, expireTime, expireFn, timestampFn, replicate, serializeOldValue)
 
         _map = useCluster ? svc.replicatedCachedValuesMap : svc.localCachedValuesMap
         if (onChange) addChangeHandler(onChange)

--- a/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
@@ -37,7 +37,7 @@ class CachedValue<V> extends BaseCache<V> {
     ) {
         super(name, svc, expireTime, expireFn, timestampFn, replicate, serializeOldValue)
 
-        _map = useCluster ? svc.replicatedCachedValuesMap : svc.localCachedValuesMap
+        _map = svc.getMapForCachedValue(this)
         if (onChange) addChangeHandler(onChange)
     }
 

--- a/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
@@ -114,4 +114,12 @@ class CachedValue<V> extends BaseCache<V> {
         }
         onChange << handler
     }
+
+    Map getAdminStats() {
+        [
+            name     : name,
+            type     : 'CachedValue' + (replicate ? ' (replicated)' : ''),
+            timestamp: timestamp
+        ]
+    }
 }

--- a/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/CachedValue.groovy
@@ -19,11 +19,7 @@ class CachedValue<V> extends BaseCache<V> {
 
     private final Map<String, Entry<V>> _map
 
-    /**
-     * @internal
-     *
-     * Not typically created directly. Use BaseService.createCachedValue() instead.
-     */
+    /** @internal - do not construct directly - use {@link BaseService#createCachedValue}. */
     @NamedVariant
     CachedValue(
         @NamedParam(required = true) String name,

--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -81,10 +81,9 @@ class DefaultRoleService extends BaseRoleService {
     DefaultRoleUpdateService defaultRoleUpdateService
 
     private Timer timer
-    protected CachedValue<Map<String, Set<String>>> _allRoleAssignments = new CachedValue(
+    protected CachedValue<Map<String, Set<String>>> _allRoleAssignments = createCachedValue(
         name: 'roleAssignments',
         replicate: true,
-        svc: this,
         onChange: {
             _roleAssignmentsByUser = new ConcurrentHashMap()
         }
@@ -103,8 +102,8 @@ class DefaultRoleService extends BaseRoleService {
 
         timer = createTimer(
             name: 'refreshRoles',
-            interval: { config.refreshIntervalSecs as int * SECONDS },
             runFn: this.&refreshRoleAssignments,
+            interval: { config.refreshIntervalSecs as int * SECONDS },
             runImmediatelyAndBlock: true,
             primaryOnly: true
         )

--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -102,6 +102,7 @@ class DefaultRoleService extends BaseRoleService {
         ensureRequiredConfigAndRolesCreated()
 
         timer = createTimer(
+            name: 'refreshRoles',
             interval: { config.refreshIntervalSecs as int * SECONDS },
             runFn: this.&refreshRoleAssignments,
             runImmediatelyAndBlock: true,

--- a/src/main/groovy/io/xh/hoist/util/Timer.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Timer.groovy
@@ -155,7 +155,7 @@ class Timer {
                 throw new IllegalArgumentException("A 'primaryOnly' timer must be owned by an instance of BaseService.")
             }
 
-            _lastCompletedOnCluster = (owner as BaseService).createCachedValue(name: "${name}_lastCompleted")
+            _lastCompletedOnCluster = (owner as BaseService).createCachedValue(name: "xh_${name}_lastCompleted")
         }
 
         intervalMs = calcIntervalMs()
@@ -201,12 +201,12 @@ class Timer {
     }
 
     /**
-     * Information about this time for admin purposes.
+     * Information about this timer for admin purposes.
      */
     Map getAdminStats() {
         [
             name: name,
-            primaryOnly: primaryOnly?: null,
+            type: 'Timer' + (primaryOnly ? ' (primary only)': ''),
             intervalMs: intervalMs,
             isRunning: isRunning,
             startTime: isRunning ? _lastRunStarted: null,

--- a/src/main/groovy/io/xh/hoist/util/Timer.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Timer.groovy
@@ -321,14 +321,14 @@ class Timer {
     // frequently enough to pickup forceRun reasonably fast. Tighten down for the rare fast timer.
     //-------------------------------------------------------------------------------------------
     private void onCoreTimer() {
-        if (!isRunning && (forceRun || isIntervalElapsed())) {
+        if (!isRunning && (forceRun || intervalHasElapsed())) {
             boolean wasForced = forceRun
             doRun()
             if (wasForced) forceRun = false
         }
     }
 
-    private boolean isIntervalElapsed() {
+    private boolean intervalHasElapsed() {
         if (intervalMs <= 0) return false
         def lastRun = _lastCompletedOnCluster ? _lastCompletedOnCluster.get() : _lastRunCompleted
         return intervalElapsed(intervalMs, lastRun)


### PR DESCRIPTION
+ New BaseService factory methods + Docs
+ Require/Check unique names for *all *service resources
+ Use NamedVariant for Timer
+ Improvements to `Timer` to avoid extra executions when primary instance changes

+ Unrelated cleanups to Timer declarations and deprecate `onTimer`
+ Logs should get archived on non-primary server as well

See also change on toolbox
