### PR TITLE
Updated behavior of `withInfo` and `withDebug`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 * Improved the handling of track log timestamps - these can now be supplied by the client and are no
   longer bound to insert time of DB record. Latest Hoist React uses *start* of the tracked activity.
 
+### ⚙️ Technical
+
+* Updated behavior of `withInfo` and `withDebug` log utils to print a "started" message if logging
+  enabled at `DEBUG` or `TRACE`, respectively. Allows admins to see start messages for more
+  important `withInfo` logs, without necessarily printing both lines for all `withDebug` calls.
+
 ## 23.0.0 - 2024-09-27
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)

--- a/src/main/groovy/io/xh/hoist/log/LogSupport.groovy
+++ b/src/main/groovy/io/xh/hoist/log/LogSupport.groovy
@@ -126,11 +126,9 @@ trait LogSupport {
     private <T> T loggedDo(Logger log, Level level, Object msgs, Closure<T> c) {
         Map meta = getMeta() ?: [:];
 
-        // Log *start* of closure execution if logging enabled @ one level finer than the main log level.
-        // Ie setting level to debug will start showing INFO start msgs, up to trace to show DEBUG start msgs.
-        if (
-            (level == INFO && log.debugEnabled) || (level == DEBUG && log.traceEnabled) || level == TRACE
-        ) {
+        // Log *start* of closure execution if at a fine run-time level. Use debug to get
+        // start msgs for your 'withInfo' logs, trace for your 'withDebug/withTrace'
+        if ((log.debugEnabled && level == INFO) || log.traceEnabled) {
             meta << [_status: 'started']
             logAtLevel(log, level, msgs, meta)
         }

--- a/src/main/groovy/io/xh/hoist/log/LogSupport.groovy
+++ b/src/main/groovy/io/xh/hoist/log/LogSupport.groovy
@@ -126,7 +126,11 @@ trait LogSupport {
     private <T> T loggedDo(Logger log, Level level, Object msgs, Closure<T> c) {
         Map meta = getMeta() ?: [:];
 
-        if (log.debugEnabled) {
+        // Log *start* of closure execution if logging enabled @ one level finer than the main log level.
+        // Ie setting level to debug will start showing INFO start msgs, up to trace to show DEBUG start msgs.
+        if (
+            (level == INFO && log.debugEnabled) || (level == DEBUG && log.traceEnabled) || level == TRACE
+        ) {
             meta << [_status: 'started']
             logAtLevel(log, level, msgs, meta)
         }


### PR DESCRIPTION
+ Only log a "started" message if logging enabled at `DEBUG` or `TRACE`, respectively.
+ Allows admins to see start messages for more important `withInfo` logs, without necessarily printing both lines for all `withDebug` calls.