### PR TITLE
Adjust App Log Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 26.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+* Misc. Improvements to ViewManager
+
 ## 25.0.0 - 2024-11-15
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 26.0-SNAPSHOT - unreleased
 
 ### ⚙️ Technical
-* Misc. Improvements to ViewManager
+* Align all-built in log names to have form "App-Cluster-xxx.log"
 
 ## 25.0.0 - 2024-11-15
 

--- a/src/main/groovy/io/xh/hoist/configuration/LogbackConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/configuration/LogbackConfig.groovy
@@ -86,9 +86,10 @@ class LogbackConfig {
     static void defaultConfig(Script script) {
         withDelegate(script) {
 
-            def appLogName = "${Utils.appCode}-${ClusterService.instanceName}",
-                trackLogName = "$appLogName-track",
-                monitorLogName = "$appLogName-monitor"
+            def appLogRoot = "${Utils.appCode}-${ClusterService.instanceName}",
+                appLogName = "$appLogRoot-app",
+                trackLogName = "$appLogRoot-track",
+                monitorLogName = "$appLogRoot-monitor"
 
             //----------------------------------
             // Register Hoist-Core's Conversion Specifiers


### PR DESCRIPTION
For easier identification/sorting of the main log with its siblings logs on a given date.