### PR TITLE
Separate configs for support and feedback emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 27.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 TRIVIAL - new feedback email config.)
+
+* Apps require a new `xhEmailFeedback` config, allowing different recipients for feedback versus
+  support requests.
+
 ## 26.0.0 - 2024-12-02
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 TRIVIAL - change to runOnInstance signature.)

--- a/grails-app/services/io/xh/hoist/feedback/FeedbackEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/feedback/FeedbackEmailService.groovy
@@ -26,7 +26,7 @@ class FeedbackEmailService extends BaseService {
     // Implementation
     //------------------------
     private void emailFeedback(Feedback fb) {
-        def to = emailService.parseMailConfig('xhEmailSupport'),
+        def to = emailService.parseMailConfig('xhEmailFeedback'),
             subject = "${Utils.appName} feedback"
 
         if (to) {


### PR DESCRIPTION
Currently, the email address configured for support is used for feedback notification emails. Applications may want to add additional recipients to receive application feedback emails, but not support requests.