### PR TITLE
`runOnAllInstances` takes a `ClusterJsonRequest` rather than a `ClusterRequest`

### DIFF
--- a/grails-app/controllers/io/xh/hoist/BaseController.groovy
+++ b/grails-app/controllers/io/xh/hoist/BaseController.groovy
@@ -106,7 +106,7 @@ abstract class BaseController implements LogSupport, IdentitySupport {
      * Run a task on *all* instances.
      * Renders a Map of instance name to ClusterResponse.
      */
-    protected void runOnAllInstances(ClusterRequest task) {
+    protected void runOnAllInstances(ClusterJsonRequest task) {
         renderJSON(clusterService.submitToAllInstances(task))
     }
 


### PR DESCRIPTION
Brings the API in line with `runOnPrimary` and `runOnInstance`