### PR TITLE
Remove default use of LDAP_MATCHING_RULE_IN_CHAIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## 29.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - LDAP search behavior change)
+
+* `LdapService` no longer uses `LDAP_MATCHING_RULE_IN_CHAIN` by default. See change to
+  `xhLdapConfig` if you need to revert to the previous behavior (not expected in most cases).
+
 ### 🎁 New Features
 
 * Added new endpoints to support searching the contents of `JSONBlob` entries, JSON-based user
   preferences, and JSON-based app configs.
+* Added `xhLdapConfig.useMatchingRuleInChain` flag to enable use of `LDAP_MATCHING_RULE_IN_CHAIN`.
 
 ### ⚙️ Technical
 

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -233,6 +233,7 @@ class BootStrap implements LogSupport {
                     enabled: false,
                     timeoutMs: 60000,
                     cacheExpireSecs: 300,
+                    useMatchingRuleInChain: false,
                     servers: [
                         [
                             host: '',

--- a/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
+++ b/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
@@ -159,7 +159,7 @@ class LdapService extends BaseService {
         config.useMatchingRuleInChain ?
             // See class-level comment regarding this AD-specific query
             searchMany("(|(memberOf=$dn) (memberOf:1.2.840.113556.1.4.1941:=$dn))", LdapPerson, strictMode) :
-            lookupGroupMembersRecursive(dn, strictMode)
+            lookupGroupMembersRecursive(dn, strictMode).unique { it.distinguishedname }
     }
 
     private List<LdapPerson> lookupGroupMembersRecursive(

--- a/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
+++ b/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
@@ -21,21 +21,21 @@ import static io.xh.hoist.util.DateTimeUtils.SECONDS
  *          - timeoutMs - time to wait for any individual search to resolve.
  *          - cacheExpireSecs - length of time to cache results.  Set to -1 to disable caching.
  *          - skipTlsCertVerification - true to accept untrusted certificates when binding
- *          - servers - list of servers to be queried, each containing:
- *              - host
- *              - baseUserDn
- *              - baseGroupDn
+ *          - useMatchingRuleInChain - true to use Microsoft Active Directory's proprietary
+ *           "LDAP_MATCHING_RULE_IN_CHAIN" rule (the magic `1.2.840.113556.1.4.1941` string below).
+ *           This can be a more efficient way to resolve users in nested groups but should be used
+ *           with caution, as it can trigger a large database walk, which has a significant
+ *           performance impact that is unnecessary when queries are not expected to return deeply
+ *           nested groups.
+*           - servers - list of servers to be queried, each containing:
+*              - host
+*              - baseUserDn
+*              - baseGroupDn
  *     - 'xhLdapUsername' - dn of query user.
  *     - 'xhLdapPassword' - password for user
  *
  * This service will cache results, per server, for the configured interval.
  * This service may return partial results if any particular server fails to return results.
- *
- * Note that the implementation of `lookupGroupMembers()` is currently specific to Microsoft Active
- * Directory, due to the use of the proprietary "LDAP_MATCHING_RULE_IN_CHAIN" rule OID (the magic
- * `1.2.840.113556.1.4.1941` string below). This is an efficient way to resolve users in nested
- * groups, but would require an alternate implementation if this service is required to work with
- * more generic LDAP deployments.
  */
 class LdapService extends BaseService {
 
@@ -156,8 +156,24 @@ class LdapService extends BaseService {
     }
 
     private List<LdapPerson> lookupGroupMembersInternal(String dn, boolean strictMode) {
-        // See class-level comment regarding this AD-specific query
-        searchMany("(|(memberOf=$dn) (memberOf:1.2.840.113556.1.4.1941:=$dn))", LdapPerson, strictMode)
+        config.useMatchingRuleInChain ?
+            // See class-level comment regarding this AD-specific query
+            searchMany("(|(memberOf=$dn) (memberOf:1.2.840.113556.1.4.1941:=$dn))", LdapPerson, strictMode) :
+            lookupGroupMembersRecursive(dn, strictMode)
+    }
+
+    private List<LdapPerson> lookupGroupMembersRecursive(
+        String dn,
+        boolean strictMode,
+        Set<String> visitedGroups = new HashSet<String>()
+    ) {
+        if (!visitedGroups.add(dn)) return []
+        List<LdapPerson> users = searchMany("(memberOf=$dn)", LdapPerson, strictMode)
+        List<LdapGroup> groups = searchMany("(memberOf=$dn)", LdapGroup, strictMode)
+        groups.each { LdapGroup group ->
+            users.addAll(lookupGroupMembersRecursive(group.distinguishedname, strictMode, visitedGroups))
+        }
+        return users
     }
 
     private <T extends LdapObject> List<T> doQuery(Map server, String baseFilter, Class<T> objType, boolean strictMode) {


### PR DESCRIPTION
Client reported that our use of `LDAP_MATCHING_RULE_IN_CHAIN` has a negative performance impact on their LDAP databases and is unnecessary when querying groups without deep nesting.  Additionally, it is proprietary to MS and therefore not suitable for other LDAP implementations. This change recurses LDAP directories with its own code by default but provides a flag on `xhLdapConfig` to enable the previous implementation in cases where an AD instance uses deeply nested groups.