### PR TITLE
Convert `BaseAuthenticationService.whitelistURIs` to protected getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ See the new methods for `ClusterUtils.runOnInstance`, `ClusterUtils.runOnPrimary
 `ClusterUtils.runOnAllInstances` for more information.  In most cases, the transition to using this
 method should be mechanical, and a simplification from the use of the previous API.
 
+### ⚙️ Technical
+
+* Modified `BaseAuthenticationService` to convert `whitelistURIs` from a property to a getter, to
+  support targeted implementation overrides of just the URIs themselves, without having to override
+  `isWhitelist()`.
+
 ## 28.1.0 - 2025-02-13
 
 ### 🎁 New Features

--- a/src/main/groovy/io/xh/hoist/security/BaseAuthenticationService.groovy
+++ b/src/main/groovy/io/xh/hoist/security/BaseAuthenticationService.groovy
@@ -159,12 +159,14 @@ abstract class BaseAuthenticationService extends BaseService {
      * that URI as otherwise SSO-based apps will not have a first shot at installing a user on the
      * session within their completeAuthentication() implementations.
      */
-    protected List<String> whitelistURIs = [
-        '/ping',  // legacy alias for /xh/ping (via UrlMappings)
-        '/xh/login',
-        '/xh/logout',
-        '/xh/ping',
-        '/xh/version',
-        '/xh/authConfig'
-    ]
+    protected List<String> getWhitelistURIs() {
+        return [
+            '/ping',  // legacy alias for /xh/ping (via UrlMappings)
+            '/xh/login',
+            '/xh/logout',
+            '/xh/ping',
+            '/xh/version',
+            '/xh/authConfig'
+        ]
+    }
 }


### PR DESCRIPTION
- Support targeted implementation overrides of just the URIs themselves, without having to override `isWhitelist()`.