### PR TITLE
Harden ClusterObjectsReports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ⚙️ Technical
 
 * Support for new consolidated clients tab in Hoist-react v73.
+* Harden `ClusterObjectReport` against issues with serialization.
 
 ## 29.2.0 - 2025-04-14
 

--- a/grails-app/services/io/xh/hoist/admin/ClusterObjectsService.groovy
+++ b/grails-app/services/io/xh/hoist/admin/ClusterObjectsService.groovy
@@ -8,10 +8,12 @@ package io.xh.hoist.admin
 
 import com.hazelcast.cache.impl.CacheProxy
 import com.hazelcast.executor.impl.ExecutorServiceProxy
+
 import io.xh.hoist.AdminStats
 import io.xh.hoist.BaseService
 
-import static io.xh.hoist.util.ClusterUtils.runOnAllInstances
+import static io.xh.hoist.json.JSONParser.parseArray
+import static io.xh.hoist.util.ClusterUtils.runOnAllInstancesAsJson
 import static java.lang.System.currentTimeMillis
 
 class ClusterObjectsService extends BaseService {
@@ -19,13 +21,9 @@ class ClusterObjectsService extends BaseService {
 
     ClusterObjectsReport getClusterObjectsReport() {
         def startTimestamp = currentTimeMillis(),
-            info = runOnAllInstances(this.&listClusterObjects).collectMany { it.value.value }
+            info = runOnAllInstancesAsJson(this.&listClusterObjects).collectMany { parseArray(it.value.value) }
 
-        return new ClusterObjectsReport(
-            info: info,
-            startTimestamp: startTimestamp,
-            endTimestamp: currentTimeMillis()
-        )
+        return new ClusterObjectsReport(info, startTimestamp, currentTimeMillis())
     }
 
     /**

--- a/grails-app/services/io/xh/hoist/admin/ClusterObjectsService.groovy
+++ b/grails-app/services/io/xh/hoist/admin/ClusterObjectsService.groovy
@@ -8,7 +8,6 @@ package io.xh.hoist.admin
 
 import com.hazelcast.cache.impl.CacheProxy
 import com.hazelcast.executor.impl.ExecutorServiceProxy
-
 import io.xh.hoist.AdminStats
 import io.xh.hoist.BaseService
 
@@ -16,12 +15,24 @@ import static io.xh.hoist.json.JSONParser.parseArray
 import static io.xh.hoist.util.ClusterUtils.runOnAllInstancesAsJson
 import static java.lang.System.currentTimeMillis
 
+/**
+ * Service to harvest and report on information about distributed objects replicated across a
+ * Hazelcast cluster. Powers the Cluster > Objects tab within the Hoist Admin Console.
+ *
+ * "Cluster Objects" include instances of Hoist services and any {@link AdminStats} they
+ * expose as well as their managed {@link BaseService#resources} such as Caches, CachedValues,
+ * and Timers created via the provided factories. Info on Hazelcast's built-in DistributedObjects
+ * are also included, as well as Hibernate caches.
+ *
+ * This service also exposes Hoist's admin API for clearing Hibernate caches.
+ */
 class ClusterObjectsService extends BaseService {
     def grailsApplication
 
     ClusterObjectsReport getClusterObjectsReport() {
         def startTimestamp = currentTimeMillis(),
-            info = runOnAllInstancesAsJson(this.&listClusterObjects).collectMany { parseArray(it.value.value) }
+            info = runOnAllInstancesAsJson(this.&listClusterObjects)
+                .collectMany { parseArray(it.value.value) }
 
         return new ClusterObjectsReport(info, startTimestamp, currentTimeMillis())
     }
@@ -30,7 +41,9 @@ class ClusterObjectsService extends BaseService {
      * Clear all Hibernate caches, or a specific list of caches by name.
      */
     void clearHibernateCaches(List<String> names = null) {
-        def caches = clusterService.distributedObjects.findAll {it instanceof CacheProxy}
+        def caches = clusterService.distributedObjects
+            .findAll { it instanceof CacheProxy }
+
         names ?= caches*.name
         names.each { name ->
             def obj = caches.find { it.name == name }

--- a/src/main/groovy/io/xh/hoist/admin/ClusterObjectInfo.groovy
+++ b/src/main/groovy/io/xh/hoist/admin/ClusterObjectInfo.groovy
@@ -2,12 +2,11 @@ package io.xh.hoist.admin
 
 import io.xh.hoist.AdminStats
 import io.xh.hoist.json.JSONFormat
+import io.xh.hoist.log.LogSupport
 
 import static io.xh.hoist.util.Utils.getClusterService
-import static java.util.Collections.emptyList
-import static java.util.Collections.emptyMap
 
-class ClusterObjectInfo implements JSONFormat {
+class ClusterObjectInfo implements JSONFormat, LogSupport {
     String name   // Absolute name. Make sure to use `svc.hzName(name)` on relative-named objects
     String type
     Map adminStats
@@ -21,18 +20,14 @@ class ClusterObjectInfo implements JSONFormat {
             adminStats = target.adminStats
             comparableAdminStats = target.comparableAdminStats
         } catch (Exception e) {
-            adminStats = emptyMap()
-            comparableAdminStats = emptyList()
+            adminStats = [:]
+            comparableAdminStats = []
             error = "Error computing admin stats | ${e.message}"
+            logError("Error computing admin stats", [_name: name], e)
         }
         name = config.name ?: adminStats.name
         type = config.type ?: adminStats.type
         instanceName = clusterService.localName
-    }
-
-    boolean isMatching(ClusterObjectInfo other) {
-        comparableAdminStats == other.comparableAdminStats &&
-            comparableAdminStats.every { f -> adminStats[f] == other.adminStats[f]}
     }
 
     Map formatForJSON() {

--- a/src/main/groovy/io/xh/hoist/admin/ClusterObjectsReport.groovy
+++ b/src/main/groovy/io/xh/hoist/admin/ClusterObjectsReport.groovy
@@ -2,6 +2,13 @@ package io.xh.hoist.admin
 
 import io.xh.hoist.json.JSONFormat
 
+/**
+ * A consolidated report sourced from serialized {@link ClusterObjectInfo} objects.
+ * These are DTOs to report on a distributed object with state that is useful to inspect
+ * via the Admin Console and/or reconcile across different instances in the cluster.
+ *
+ * @see ClusterObjectsService
+ */
 class ClusterObjectsReport implements JSONFormat {
 
     // List of all of the distributed object data from all of the instances in the cluster.

--- a/src/main/groovy/io/xh/hoist/admin/HzAdminStats.groovy
+++ b/src/main/groovy/io/xh/hoist/admin/HzAdminStats.groovy
@@ -21,8 +21,8 @@ import static java.util.Collections.emptyMap
  */
 class HzAdminStats implements AdminStats {
 
-    private Map _stats = emptyMap()
-    private List<String> _comparables = emptyList()
+    private Map _stats
+    private List<String> _comparables
 
     Map getAdminStats() {
         _stats
@@ -80,6 +80,7 @@ class HzAdminStats implements AdminStats {
                 break
             case ITopic:
                 def stats = obj.getLocalTopicStats()
+                _comparables = []
                 _stats = [
                     name                 : obj.getName(),
                     type                 : 'Topic',
@@ -88,6 +89,7 @@ class HzAdminStats implements AdminStats {
                 ]
                 break
             case RingbufferProxy:
+                _comparables = []
                 _stats = [
                     name    : obj.getName(),
                     type    : 'Ringbuffer',
@@ -119,6 +121,7 @@ class HzAdminStats implements AdminStats {
                 ]
                 break
             default:
+                _comparables = []
                 _stats = [
                     name: obj.getName(),
                     type: obj.class.toString()


### PR DESCRIPTION
+ Remove potentially problematic usage of emptyMap/emptyList.
+ Improve Logging
+ Use JSON serialization to harden against non-serializable implementations of getAdminStats() 