### PR TITLE
Default newly promoted global views to "pinned by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 32.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Updated ViewManager to set newly promoted global views to be "pinned by default" for all users,
+  avoiding an extra step for the common case where a global view should be readily visible to all.
+
 ## 31.1.0 - 2025-08-07
 
 ### ⚙️ Technical

--- a/grails-app/services/io/xh/hoist/view/ViewService.groovy
+++ b/grails-app/services/io/xh/hoist/view/ViewService.groovy
@@ -156,8 +156,14 @@ class ViewService extends BaseService {
     /** Make a view global */
     Map makeGlobal(String token, String username = username) {
         def existing = jsonBlobService.get(token, username),
-            meta = parseObject(existing.meta)?.findAll { it.key != 'isShared' },
-            ret = jsonBlobService.update(token, [owner: null, acl: '*', meta: meta], username)
+            meta = parseObject(existing.meta)?.findAll { it.key != 'isShared' } ?: [:]
+
+        // When promoting to a global view, pin to all user menus by default, w/expectation that
+        // the newly global view should be seen by all users in their menu. The user promoting the
+        // view still has option to turn this off if not desired.
+        meta.isDefaultPinned = true
+
+        def ret = jsonBlobService.update(token, [owner: null, acl: '*', meta: meta], username)
 
         trackChange('Made View Global', ret)
         ret.formatForClient(true)


### PR DESCRIPTION
* Updated ViewManager to set newly promoted global views to be "pinned by default" for all users,
  avoiding an extra step for the common case where a global view should be readily visible to all.