### PR TITLE
Use User Agent 'Hint' Headers in Browser detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Changelog
 
-## 31.2.0 - 2025-08-27
+## 32.0.0 - 2025-08-27
+
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - removed methods unlikely to be used)
+
+* This version of hoist standardizes and improves how we recognize browsers and devices to use
+  additional standard 'hint' HTTP headers (see below).  As part of this change, the detection
+  utilities in `io.xh.hoist.browser.Utils` was greatly simplified, and several unsupportable
+  methods were removed.
 
 ### ⚙️ Technical
 
 ### 🎁 New Features
-* Improved support for parsing browsers and devices.  Hoist now consults the new `Sec-Ch-UA` and
-  `Sec-Ch-UA-Platform` http headers as well as `User-Agent`.  We have also removed an obsolete
-   special workarounds for detecting iOS Homescreen apps.
+* Improved support for parsing browsers and devices.  Hoist now consults the standard `Sec-Ch-UA`
+  and `Sec-Ch-UA-Platform` http headers as well as `User-Agent`.  We have also removed an obsolete
+  special workaround for detecting iOS Homescreen apps.
 
 * Support clearing basic view state via hoist-react `restoreDefaultsAsync`
   (requires hoist-react v76)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### ⚙️ Technical
 
+### 🎁 New Features
+* Improved support for parsing browsers and devices.  Hoist now consults the new `Sec-Ch-UA` and
+  `Sec-Ch-UA-Platform` http headers as well as `User-Agent`.  We have also removed an obsolete
+   special workarounds for detecting iOS Homescreen apps.
+
 * Support clearing basic view state via hoist-react `restoreDefaultsAsync`
   (requires hoist-react v76)
 

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -202,7 +202,6 @@ class TrackService extends BaseService {
     // Implementation
     //-------------------------
     private Map prepareEntry(Map entry) {
-        String userAgent = currentRequest?.getHeader('User-Agent')
         return [
             // From submission
             username      : entry.username ?: authUsername,
@@ -224,9 +223,9 @@ class TrackService extends BaseService {
             // From request/context
             instance      : ClusterService.instanceName,
             appEnvironment: Utils.appEnvironment,
-            userAgent     : userAgent,
-            browser       : getBrowser(userAgent),
-            device        : getDevice(userAgent)
+            userAgent     : currentRequest?.getHeader('User-Agent'),
+            browser       : getBrowser(currentRequest),
+            device        : getDevice(currentRequest)
         ]
     }
 

--- a/src/main/groovy/io/xh/hoist/browser/Browser.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Browser.groovy
@@ -16,7 +16,6 @@ enum Browser {
     ISLAND('Island'),
     OPERA('Opera'),
     SAFARI('Safari'),
-    IOS_HOMESCREEN('iOS Homescreen'),
     OTHER('Unknown')
 
     final String displayName

--- a/src/main/groovy/io/xh/hoist/browser/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Utils.groovy
@@ -14,9 +14,28 @@ import javax.servlet.http.HttpServletRequest
 
 class Utils {
 
-    private static Map<String, Browser> BROWSERS_MATCHERS = [
+    //----------------------
+    // Public Entry points
+    //----------------------
+    static Browser getBrowser(HttpServletRequest request) {
+        if (!request) return null
+        def ua = request?.getHeader('User-Agent'),
+            uaHint = request?.getHeader('Sec-Ch-UA')
+        findMatch(uaHint, BROWSER_MATCHERS) ?: findMatch(ua, BROWSER_MATCHERS) ?: Device.OTHER
+    }
+
+    static Device getDevice(HttpServletRequest request) {
+        if (!request) return null
+        def ua = request.getHeader('User-Agent'),
+            uaPlatformHint = request.getHeader('Sec-Ch-UA-Platform')
+
+        findMatch(ua, DEVICE_MATCHERS) ?: findMatch(uaPlatformHint, DEVICE_MATCHERS) ?: Device.OTHER
+    }
+
+    private static Map<String, Browser> BROWSER_MATCHERS = [
             'Island': ISLAND,   // Island must come before chrome
             'Firefox': FIREFOX, // Firefox must come before "; rv" to prevent identification as IE
+            'Edge': EDGE,       // Desktop Edge
             'EdgiOS': EDGE,     // iOS Edge
             'EdgA': EDGE,       // Android Edge
             'Edg': EDGE,        // Desktop Edge
@@ -29,77 +48,19 @@ class Utils {
             'Safari': SAFARI    // Safari must come after Chrome to prevent false positives
     ]
 
-    private static Map<String, Map<String,String>> BROWSER_VERSION_MATCHERS = [
-            'EdgiOS': [start: 'EdgiOS/', end: ' '],
-            'EdgA': [start: 'EdgA/', end: null],
-            'Edg': [start: 'Edg/', end: null],
-            '; rv': [start: '; rv:', end: ')'],
-            'MSIE': [start: 'MSIE ', end: ';'],
-            'Opera': [start: 'Opera/', end: null], // Opera must come before Chrome and Safari to prevent false positives
-            'OPR': [start: 'OPR/', end: null], // Opera must come before Chrome and Safari to prevent false positives
-            'Chrome': [start: 'Chrome/', end: ' '],
-            'CriOS': [start: 'CriOS/', end: ' '], // Mobile Chrome
-            'Safari': [start: 'Version/', end: ' '], // Safari uses nonstandard 'Version/', and must come after Chrome to prevent false positives
-            'Firefox': [start: 'Firefox/', end: null]
-    ]
-
     private static Map<String, Device> DEVICE_MATCHERS = [
-            'Windows': WINDOWS,
-            'Android': ANDROID,
-            'Linux': LINUX,  // Linux must come after Android to prevent false positives
-            'Macintosh': MAC,
-            'iPhone': IPHONE,
-            'iPad': IPAD,
-            'iPod': IPOD,
-            'Mac OS X': MAC  // Mac OS X must come after iPhone|iPad|iPod to prevent false positives
+        'Windows': WINDOWS,
+        'Android': ANDROID,
+        'Linux': LINUX,  // Linux must come after Android to prevent false positives
+        'iPhone': IPHONE,
+        'iPad': IPAD,
+        'iPod': IPOD,
+        'Mac OS X': MAC, // MAC must come after iPhone|iPad|iPod to prevent false positives
+        'Macintosh': MAC,
+        'macOS': MAC
     ]
 
-    private static List IOS_DEVICES = [IPAD, IPOD, IPHONE]
-
-    static Browser getBrowser(String userAgent) {
-        if (!userAgent) return null
-
-        // 1) Standard Browser
-        def match = BROWSERS_MATCHERS.find {key, value -> userAgent.contains(key) }?.value
-        if (match) return match
-
-        // 2) Catch special iOS homescreen
-        // iOS devices running in home-screen mode present a non-standard user-agent
-        // which prevents us from extracting a standardized browser name or version.
-        def isIos = isIosDevice(userAgent),
-            version = getBrowserVersion(userAgent),
-            majorVersionString = version?.tokenize('.')?.first(),
-            majorVersion = majorVersionString?.isInteger() ? majorVersionString as Integer : null
-        if (isIos && !majorVersion) return IOS_HOMESCREEN
-
-        // 3) Next big thing
-        return Browser.OTHER
+    private static <T> T findMatch(Map<String, T> targets, String header) {
+        header ? targets.find {header.contains(it.key) }?.value : null
     }
-
-    static String getBrowserVersion(String userAgent) {
-        if (!userAgent) return null
-        def matcher = BROWSER_VERSION_MATCHERS.find {key, value -> userAgent.contains(key) }?.value
-        if (!matcher || !userAgent.contains(matcher.start) || (matcher.end && !userAgent.contains(matcher.end))) return 'Unknown'
-
-        def startStr = userAgent.substring(userAgent.indexOf(matcher.start) + matcher.start.length()),
-            version = matcher.end ? startStr.substring(0, startStr.indexOf(matcher.end)) : startStr
-
-        return version ?: 'Unknown'
-    }
-
-    static Device getDevice(String userAgent) {
-        if (!userAgent) return null
-        def match = DEVICE_MATCHERS.find {key, value -> userAgent.contains(key)}?.value
-        return match ?: Device.OTHER
-    }
-
-    static boolean isIosDevice(String userAgent) {
-        return IOS_DEVICES.contains(getDevice(userAgent))
-    }
-
-    // Request-based convenience methods.
-    static String  getAgent(HttpServletRequest request)             {request?.getHeader('User-Agent')}
-    static Browser getBrowser(HttpServletRequest request)           {getBrowser(getAgent(request))}
-    static Device  getDevice(HttpServletRequest request)            {getDevice(getAgent(request))}
-    static boolean browserSupported(HttpServletRequest request)     {browserSupported(getAgent(request))}
 }

--- a/src/main/groovy/io/xh/hoist/browser/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Utils.groovy
@@ -56,7 +56,7 @@ class Utils {
         'macOS': MAC
     ]
 
-    private static <T> T findMatch(String header, Map<String, T> targets) {
+    private static <T extends Object> T findMatch(String header, Map<String, T> targets) {
         header ? targets.find {header.contains(it.key) }?.value : null
     }
 }

--- a/src/main/groovy/io/xh/hoist/browser/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Utils.groovy
@@ -14,21 +14,17 @@ import javax.servlet.http.HttpServletRequest
 
 class Utils {
 
-    //----------------------
-    // Public Entry points
-    //----------------------
     static Browser getBrowser(HttpServletRequest request) {
         if (!request) return null
         def ua = request?.getHeader('User-Agent'),
             uaHint = request?.getHeader('Sec-Ch-UA')
-        findMatch(uaHint, BROWSER_MATCHERS) ?: findMatch(ua, BROWSER_MATCHERS) ?: Device.OTHER
+        findMatch(uaHint, BROWSER_MATCHERS) ?: findMatch(ua, BROWSER_MATCHERS) ?: Browser.OTHER
     }
 
     static Device getDevice(HttpServletRequest request) {
         if (!request) return null
         def ua = request.getHeader('User-Agent'),
             uaPlatformHint = request.getHeader('Sec-Ch-UA-Platform')
-
         findMatch(ua, DEVICE_MATCHERS) ?: findMatch(uaPlatformHint, DEVICE_MATCHERS) ?: Device.OTHER
     }
 

--- a/src/main/groovy/io/xh/hoist/browser/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Utils.groovy
@@ -16,8 +16,8 @@ class Utils {
 
     static Browser getBrowser(HttpServletRequest request) {
         if (!request) return null
-        def ua = request?.getHeader('User-Agent'),
-            uaHint = request?.getHeader('Sec-Ch-UA')
+        def ua = request.getHeader('User-Agent'),
+            uaHint = request.getHeader('Sec-Ch-UA')
         findMatch(uaHint, BROWSER_MATCHERS) ?: findMatch(ua, BROWSER_MATCHERS) ?: Browser.OTHER
     }
 
@@ -25,9 +25,12 @@ class Utils {
         if (!request) return null
         def ua = request.getHeader('User-Agent'),
             uaPlatformHint = request.getHeader('Sec-Ch-UA-Platform')
-        findMatch(ua, DEVICE_MATCHERS) ?: findMatch(uaPlatformHint, DEVICE_MATCHERS) ?: Device.OTHER
+        findMatch(uaPlatformHint, DEVICE_MATCHERS) ?: findMatch(ua, DEVICE_MATCHERS) ?: Device.OTHER
     }
 
+    //--------------------
+    // Implementation
+    //--------------------
     private static Map<String, Browser> BROWSER_MATCHERS = [
             'Island': ISLAND,   // Island must come before chrome
             'Firefox': FIREFOX, // Firefox must come before "; rv" to prevent identification as IE

--- a/src/main/groovy/io/xh/hoist/browser/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/browser/Utils.groovy
@@ -56,7 +56,7 @@ class Utils {
         'macOS': MAC
     ]
 
-    private static <T> T findMatch(Map<String, T> targets, String header) {
+    private static <T> T findMatch(String header, Map<String, T> targets) {
         header ? targets.find {header.contains(it.key) }?.value : null
     }
 }


### PR DESCRIPTION
Was motivated by client using Island browser, which is now only publishing its identity using the new headers.
Also some issues with device detection for this browser, which also requires the new headers.

This also unwinds some very ancient iOS homescreen code that we believe to be obsolete.

Note that we have probably reached our limits with our custom UA sniffing -- but could not see an easily dropped in java library -- `ua-parser` and `Yauaa` would require some work around multi-threading.  For now -- just extending and simplifying our existing approach seemed pragmatic.
