### PR TITLE
Restore Timer Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 34.0-SNAPSHOT - unreleased
 
+
+### 🐞 Bug Fixes
+
+* Restore display of Timers in Service AdminStats.
+
 ## 33.0.0 - 2025-09-26
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - exception handling syntax )

--- a/src/main/groovy/io/xh/hoist/util/Timer.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Timer.groovy
@@ -225,7 +225,8 @@ class Timer implements LogSupport, AdminStats {
     Map getAdminStats() {
         [
             name      : name,
-            type      : 'Timer' + (primaryOnly ? ' (primary only)' : ''),
+            type      : 'Timer',
+            primaryOnly: primaryOnly,
             intervalMs: intervalMs,
             isRunning : isRunning,
             startTime : isRunning ? _lastRunStarted : null,


### PR DESCRIPTION
Not sure how we dropped the ball here.  We have numerous comments saying they will be reported, just like Cache and CachedValue, etc. 

Maybe a merge issue ?  Feels like deja vu.

Please merge if this makes sense.