### PR TITLE
Grails patch version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
    of access control then then the existing `@Access` annotation.  `@Access` has been deprecated and
    will be removed in a future version of Hoist.
 
+### 📚 Libraries
+
+* grails `7.0.4 → 7.0.5`
+
 ## 35.0.0 - 2026-01-05
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 TRIVIAL, types only)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 xhReleaseVersion=36.0-SNAPSHOT
 
-grailsVersion=7.0.4
+grailsVersion=7.0.5
 
 hazelcast.version=5.6.0
 

--- a/src/main/groovy/io/xh/hoist/HoistCoreGrailsPlugin.groovy
+++ b/src/main/groovy/io/xh/hoist/HoistCoreGrailsPlugin.groovy
@@ -21,7 +21,7 @@ import static io.xh.hoist.util.Utils.createCustomOrDefault
 
 class HoistCoreGrailsPlugin extends Plugin {
 
-    def grailsVersion = '7.0.4'
+    def grailsVersion = '7.0.4 > *'
     def version = '36.0-SNAPSHOT'
     def title = 'hoist-core'
     def author = 'Extremely Heavy'


### PR DESCRIPTION
- Update the plugin's own version of Grails to latest 7.0.5 patch release.
- Update plugin's spec for the Grails version expected in its apps to `7.0.4 > *`.
  - Allows apps to update to newer versions without logging a warning, with `> *` as per Grails plugin docs and bundled plugins.