### PR TITLE
Upgrade hoist-core mcp to latest sdk

### DIFF
--- a/mcp/build.gradle
+++ b/mcp/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.modelcontextprotocol.sdk:mcp:0.12.1'
+    implementation 'io.modelcontextprotocol.sdk:mcp:1.1.0'
     implementation 'org.apache.groovy:groovy:4.0.26'
     implementation 'org.apache.groovy:groovy-json:4.0.26'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.+'

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/HoistCoreMcpServer.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/HoistCoreMcpServer.groovy
@@ -2,6 +2,7 @@ package io.xh.hoist.mcp
 
 import io.modelcontextprotocol.server.McpServer
 import io.modelcontextprotocol.server.McpSyncServer
+import io.modelcontextprotocol.json.McpJsonDefaults
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities
 import io.xh.hoist.mcp.data.DocRegistry
@@ -63,7 +64,7 @@ class HoistCoreMcpServer {
 
         def toolSpecs = DocTools.create(docRegistry) + GroovyTools.create(groovyRegistry)
 
-        def transportProvider = new StdioServerTransportProvider()
+        def transportProvider = new StdioServerTransportProvider(McpJsonDefaults.getMapper())
 
         McpSyncServer server = McpServer.sync(transportProvider)
             .serverInfo('hoist-core', this.class.package.implementationVersion ?: 'dev')

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/tools/DocTools.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/tools/DocTools.groovy
@@ -3,6 +3,7 @@ package io.xh.hoist.mcp.tools
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult
 import io.modelcontextprotocol.spec.McpSchema.JsonSchema
+import io.modelcontextprotocol.spec.McpSchema.TextContent
 import io.modelcontextprotocol.spec.McpSchema.Tool
 import io.xh.hoist.mcp.data.DocRegistry
 
@@ -56,7 +57,8 @@ class DocTools {
             ))
             .build()
 
-        return new SyncToolSpecification(tool, { exchange, args ->
+        return new SyncToolSpecification(tool, { exchange, request ->
+            def args = request?.arguments() ?: [:]
             String query = args?.query ?: ''
             String category = args?.category
             int limit = (args?.limit as Integer) ?: 10
@@ -80,7 +82,11 @@ class DocTools {
                 text = lines.join('\n')
             }
 
-            return new CallToolResult(text, false)
+            return CallToolResult
+                .builder()
+                .content([new TextContent(text)])
+                .isError(false)
+                .build()
         })
     }
 
@@ -108,7 +114,8 @@ class DocTools {
             ))
             .build()
 
-        return new SyncToolSpecification(tool, { exchange, args ->
+        return new SyncToolSpecification(tool, { exchange, request ->
+            def args = request?.arguments() ?: [:]
             String category = args?.category
 
             def filtered = registry.listDocs(category)
@@ -127,7 +134,11 @@ class DocTools {
 
             lines << 'Use hoist-core-search-docs with keywords to find specific content within documents.'
 
-            return new CallToolResult(lines.join('\n'), false)
+            return CallToolResult
+                .builder()
+                .content([new TextContent(lines.join('\n'))])
+                .isError(false)
+                .build()
         })
     }
 
@@ -142,8 +153,12 @@ class DocTools {
             .inputSchema(new JsonSchema('object', [:], [], null, null, null))
             .build()
 
-        return new SyncToolSpecification(tool, { exchange, args ->
-            return new CallToolResult('hoist-core MCP server is running.', false)
+        return new SyncToolSpecification(tool, { exchange, request ->
+            return CallToolResult
+                .builder()
+                .content([new TextContent('hoist-core MCP server is running.')])
+                .isError(false)
+                .build()
         })
     }
 }

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/tools/GroovyTools.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/tools/GroovyTools.groovy
@@ -3,6 +3,7 @@ package io.xh.hoist.mcp.tools
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult
 import io.modelcontextprotocol.spec.McpSchema.JsonSchema
+import io.modelcontextprotocol.spec.McpSchema.TextContent
 import io.modelcontextprotocol.spec.McpSchema.Tool
 import io.xh.hoist.mcp.data.GroovyRegistry
 import io.xh.hoist.mcp.data.GroovyRegistry.MemberInfo
@@ -57,7 +58,8 @@ class GroovyTools {
             ))
             .build()
 
-        return new SyncToolSpecification(tool, { exchange, args ->
+        return new SyncToolSpecification(tool, { exchange, request ->
+            def args = request?.arguments() ?: [:]
             String query = args?.query ?: ''
             String kind = args?.kind
             int symbolLimit = (args?.limit as Integer) ?: 20
@@ -96,7 +98,11 @@ class GroovyTools {
 
             def text = lines ? lines.join('\n') : "No symbols or members found matching '${query}'. Try a broader search term."
 
-            return new CallToolResult(text, false)
+            return CallToolResult
+                .builder()
+                .content([new TextContent(text)])
+                .isError(false)
+                .build()
         })
     }
 
@@ -125,7 +131,8 @@ class GroovyTools {
             ))
             .build()
 
-        return new SyncToolSpecification(tool, { exchange, args ->
+        return new SyncToolSpecification(tool, { exchange, request ->
+            def args = request?.arguments() ?: [:]
             String name = args?.name ?: ''
             String filePath = args?.filePath
 
@@ -164,7 +171,11 @@ class GroovyTools {
                 text = lines.join('\n')
             }
 
-            return new CallToolResult(text, false)
+            return CallToolResult
+                .builder()
+                .content([new TextContent(text)])
+                .isError(false)
+                .build()
         })
     }
 
@@ -193,7 +204,8 @@ class GroovyTools {
             ))
             .build()
 
-        return new SyncToolSpecification(tool, { exchange, args ->
+        return new SyncToolSpecification(tool, { exchange, request ->
+            def args = request?.arguments() ?: [:]
             String name = args?.name ?: ''
             String filePath = args?.filePath
 
@@ -241,7 +253,11 @@ class GroovyTools {
                 text = lines.join('\n')
             }
 
-            return new CallToolResult(text, false)
+            return CallToolResult
+                .builder()
+                .content([new TextContent(text)])
+                .isError(false)
+                .build()
         })
     }
 


### PR DESCRIPTION
- io.modelcontextprotocol.sdk:mcp `0.12.1 -> 1.1.0`
- Provide JSON mapper to `StdioServerTransportProvider` for JSON serialization/deserialization.
- Update `SyncToolSpecification` BiFunction to request instead of args map
- Update `CallToolResult` to builder pattern 