### PR TITLE
Include traceId in exception JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - `ObservedRun` composable builder via `BaseService.observe()` wraps a closure with any combination of tracing, logging, and Micrometer metrics in a single fluent call chain.
     - Client span relay via `ClientTraceService` — browser-generated spans are exported through the same server-side pipeline for coherent end-to-end traces.
     - Automatic trace context propagation across Grails `task {}` thread boundaries.
+    - Exception JSON responses now include `traceId` when an active trace context is available, enabling client-side correlation with server traces.
 
 * Added an MCP (Model Context Protocol) server for AI coding agents. Provides searchable access to
   all Hoist Core documentation and Groovy/Java symbol introspection (classes, interfaces, methods,

--- a/src/main/groovy/io/xh/hoist/json/serializer/ThrowableSerializer.groovy
+++ b/src/main/groovy/io/xh/hoist/json/serializer/ThrowableSerializer.groovy
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import groovy.transform.CompileStatic
+import io.opentelemetry.api.trace.Span
 import io.xh.hoist.exception.RoutineException
 import io.xh.hoist.json.JSONFormat
 
@@ -33,9 +34,15 @@ class ThrowableSerializer extends StdSerializer<Throwable> {
                 name     : t.class.simpleName,
                 message  : t.message,
                 cause    : t.cause?.message,
-                isRoutine: t instanceof RoutineException
+                isRoutine: t instanceof RoutineException,
+                traceId  : activeTraceId
             ].findAll { it.value }
 
         jgen.writeObject(ret)
+    }
+
+    private static String getActiveTraceId() {
+        def ctx = Span.current()?.spanContext
+        ctx?.valid ? ctx.traceId : null
     }
 }


### PR DESCRIPTION
## Summary
- `ThrowableSerializer` reads the active OTel span context and includes `traceId` in serialized exception JSON
- Enables client-side error dialogs to show the trace ID for server-originated errors

Companion PR: xh/hoist-react — surfaces `traceId` as a top-level property on `HoistException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)