### PR TITLE
Migrate to shared GitHub Actions from hoist-dev-utils

### DIFF
--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -9,21 +9,25 @@ name: Deploy Release
 on:
     workflow_dispatch:
         inputs:
-            xhReleaseVersion:
+            version:
                 description: 'Release Version'
                 required: true
                 type: string
-            isHotfix:
+            is-hotfix:
                 description: 'As hotfix. Check when releasing a hotfix to a version other than the latest.'
                 required: true
                 default: false
                 type: boolean
 
+concurrency:
+    group: deploy-release
+    cancel-in-progress: false
+
 jobs:
     build:
         # Guards against accidental release from develop. Requires master for standard
-        # releases and a branch other than master (or develop) when isHotfix is set.
-        if: github.ref != 'refs/heads/develop' && ((github.ref == 'refs/heads/master') != inputs.isHotfix)
+        # releases and a branch other than master (or develop) when is-hotfix is set.
+        if: github.ref != 'refs/heads/develop' && ((github.ref == 'refs/heads/master') != inputs.is-hotfix)
 
         runs-on: ubuntu-latest
         permissions:
@@ -35,84 +39,18 @@ jobs:
               fetch-depth: 0
               fetch-tags: true
 
-        - name: Validate release version and detect hotfix
-          env:
-              VERSION: ${{ inputs.xhReleaseVersion }}
-              IS_HOTFIX: ${{ inputs.isHotfix }}
-          run: |
-              # Must be semver (X.Y.Z) with no leading zeros.
-              if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-                  echo "::error::Invalid version '$VERSION'. Must be semver with no leading zeros (e.g. 37.0.0)."
-                  exit 1
-              fi
-
-              # Must not duplicate an existing release
-              if git tag -l "v$VERSION" | grep -q .; then
-                  echo "::error::Tag v$VERSION already exists. This version has already been released."
-                  exit 1
-              fi
-
-              # Strict version validation — the new version must be exactly one
-              # increment from the latest relevant tag and hotfix cannot be latest.
-              LATEST=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-              if [ -z "$LATEST" ]; then
-                  echo "::error::No existing release tags found. Cannot validate version."
-                  exit 1
-              fi
-              LATEST_MAJOR=$(echo "$LATEST" | cut -d. -f1)
-              LATEST_MINOR=$(echo "$LATEST" | cut -d. -f2)
-              LATEST_PATCH=$(echo "$LATEST" | cut -d. -f3)
-
-              # The three versions that would be valid as a standard (non-hotfix) release.
-              NEXT_MAJOR="$(( LATEST_MAJOR + 1 )).0.0"
-              NEXT_MINOR="${LATEST_MAJOR}.$(( LATEST_MINOR + 1 )).0"
-              NEXT_PATCH="${LATEST_MAJOR}.${LATEST_MINOR}.$(( LATEST_PATCH + 1 ))"
-
-              if [ "$IS_HOTFIX" = "true" ]; then
-                  # A hotfix must NOT be a standard next-release version.
-                  if [ "$VERSION" = "$NEXT_MAJOR" ] || [ "$VERSION" = "$NEXT_MINOR" ] || [ "$VERSION" = "$NEXT_PATCH" ]; then
-                      echo "::error::Hotfix version $VERSION matches a standard release increment (latest is v$LATEST). Use a standard release instead."
-                      exit 1
-                  fi
-
-                  NEW_MAJOR=$(echo "$VERSION" | cut -d. -f1)
-                  NEW_MINOR=$(echo "$VERSION" | cut -d. -f2)
-
-                  # Validate against the highest tags for this major version.
-                  MAX_MINOR=$(git tag -l "v${NEW_MAJOR}.*" | grep -E "^v${NEW_MAJOR}\.[0-9]+\.[0-9]+$" | sed 's/^v//' | cut -d. -f2 | sort -n | tail -1)
-                  if [ -z "$MAX_MINOR" ]; then
-                      echo "::error::No existing tags found for major version ${NEW_MAJOR}. Cannot validate hotfix."
-                      exit 1
-                  fi
-
-                  # Allowed: next minor bump for this major.
-                  ALLOWED_MINOR="${NEW_MAJOR}.$(( MAX_MINOR + 1 )).0"
-
-                  # Only offer a patch bump if tags exist for this specific MAJOR.MINOR.
-                  MAX_PATCH=$(git tag -l "v${NEW_MAJOR}.${NEW_MINOR}.*" | grep -E "^v${NEW_MAJOR}\.${NEW_MINOR}\.[0-9]+$" | sed 's/^v//' | cut -d. -f3 | sort -n | tail -1)
-                  if [ -n "$MAX_PATCH" ]; then
-                      ALLOWED_PATCH="${NEW_MAJOR}.${NEW_MINOR}.$(( MAX_PATCH + 1 ))"
-                  fi
-
-                  if [ "$VERSION" != "$ALLOWED_MINOR" ] && [ "$VERSION" != "${ALLOWED_PATCH:-}" ]; then
-                      ALLOWED="$ALLOWED_MINOR"
-                      [ -n "${ALLOWED_PATCH:-}" ] && ALLOWED="$ALLOWED or $ALLOWED_PATCH"
-                      echo "::error::Hotfix version $VERSION is not a valid next version. Allowed: $ALLOWED."
-                      exit 1
-                  fi
-              else
-                  # Standard release: must be exactly one increment from the latest tag.
-                  if [ "$VERSION" != "$NEXT_MAJOR" ] && [ "$VERSION" != "$NEXT_MINOR" ] && [ "$VERSION" != "$NEXT_PATCH" ]; then
-                      echo "::error::Version $VERSION is not a valid next version (latest is v$LATEST). Allowed: $NEXT_MAJOR, $NEXT_MINOR, or $NEXT_PATCH."
-                      exit 1
-                  fi
-              fi
+        - name: Validate release version
+          uses: xh/hoist-dev-utils/.github/actions/validate-release-version@develop
+          with:
+              version: ${{ inputs.version }}
+              is-hotfix: ${{ inputs.is-hotfix }}
 
         - name: Setup JDK 17
           uses: actions/setup-java@v5
           with:
               java-version: '17'
               distribution: 'zulu'
+              cache: 'gradle'
 
         - name: Setup Gradle
           uses: gradle/actions/setup-gradle@v5
@@ -123,28 +61,14 @@ jobs:
               SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
               SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
               SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-              XH_RELEASE_VERSION: ${{ inputs.xhReleaseVersion }}
+              XH_RELEASE_VERSION: ${{ inputs.version }}
           run: |
               (set -x; ./gradlew -PxhReleaseVersion="$XH_RELEASE_VERSION" publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon)
 
-        - name: Tag release
-          env:
-              VERSION: ${{ inputs.xhReleaseVersion }}
-          run: |
-              git tag "v$VERSION"
-              git push origin "v$VERSION"
-
-        - name: Create GitHub release
+        - name: Create tag and GitHub release
+          uses: xh/hoist-dev-utils/.github/actions/create-tag-and-github-release@develop
+          with:
+              version: ${{ inputs.version }}
+              is-hotfix: ${{ inputs.is-hotfix }}
           env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              VERSION: ${{ inputs.xhReleaseVersion }}
-              IS_HOTFIX: ${{ inputs.isHotfix }}
-          run: |
-              LATEST_FLAG="--latest"
-              if [ "$IS_HOTFIX" = "true" ]; then
-                  LATEST_FLAG="--latest=false"
-              fi
-              gh release create "v$VERSION" \
-                  --title "v$VERSION" \
-                  --generate-notes \
-                  "$LATEST_FLAG"

--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -19,6 +19,7 @@ on:
                 default: false
                 type: boolean
 
+# Run all release builds one-by-one, but never cancel a release build due to another one.
 concurrency:
     group: deploy-release
     cancel-in-progress: false
@@ -39,8 +40,9 @@ jobs:
               fetch-depth: 0
               fetch-tags: true
 
+        # Checkout is required to be called with `fetch-depth: 0` and `fetch-tags: true`.
         - name: Validate release version
-          uses: xh/hoist-dev-utils/.github/actions/validate-release-version@develop
+          uses: xh/hoist-dev-utils/.github/actions/validate-release-version@master
           with:
               version: ${{ inputs.version }}
               is-hotfix: ${{ inputs.is-hotfix }}
@@ -65,8 +67,13 @@ jobs:
           run: |
               (set -x; ./gradlew -PxhReleaseVersion="$XH_RELEASE_VERSION" publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon)
 
+        # Note: The tag intentionally points to a commit where gradle.properties still has
+        # the SNAPSHOT version. We chose not to commit the version change back to the repo to
+        # avoid paired set/reset commits on every release. The published Maven Central artifact
+        # has the correct release version — the tag is just a pointer to the source commit.
+        # Checkout is required to be called with `fetch-depth: 0` and `fetch-tags: true`.
         - name: Create tag and GitHub release
-          uses: xh/hoist-dev-utils/.github/actions/create-tag-and-github-release@develop
+          uses: xh/hoist-dev-utils/.github/actions/create-tag-and-github-release@master
           with:
               version: ${{ inputs.version }}
               is-hotfix: ${{ inputs.is-hotfix }}

--- a/.github/workflows/deploySnapshot.yml
+++ b/.github/workflows/deploySnapshot.yml
@@ -11,7 +11,7 @@ on:
         branches: [ "develop" ]
     workflow_dispatch:
         inputs:
-            xhSnapshotVersion:
+            version:
                 description: '(Optional) Snapshot version to override default in gradle.properties. Note that the suffix "-SNAPSHOT" will be automatically appended if not present.'
                 required: false
                 default: ''
@@ -36,14 +36,15 @@ jobs:
           with:
               java-version: '17'
               distribution: 'zulu'
+              cache: 'gradle'
 
         - name: Setup Gradle
           uses: gradle/actions/setup-gradle@v5
 
         - name: Override snapshot version in gradle.properties
-          if: inputs.xhSnapshotVersion != ''
+          if: inputs.version != ''
           env:
-              VERSION: ${{ inputs.xhSnapshotVersion }}
+              VERSION: ${{ inputs.version }}
           run: |
               if [[ ! "$VERSION" == *-SNAPSHOT ]]; then
                 VERSION="$VERSION-SNAPSHOT"
@@ -51,14 +52,15 @@ jobs:
               sed -i "s/^xhReleaseVersion=.*/xhReleaseVersion=$VERSION/" gradle.properties
               echo "Updated xhReleaseVersion to SNAPSHOT version: $VERSION"
 
-        - name: Validate SNAPSHOT version
-          run: |
-              VERSION=$(grep "^xhReleaseVersion=" gradle.properties | cut -d'=' -f2)
-              if [[ ! "$VERSION" == *-SNAPSHOT ]]; then
-                echo "::error::'$VERSION' is not a SNAPSHOT version. Aborting."
-                exit 1
-              fi
-              echo "Validated snapshot version: $VERSION"
+        - name: Read current version from gradle.properties
+          id: current-version
+          run: echo "current-version=$(grep '^xhReleaseVersion=' gradle.properties | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+
+        - name: Validate snapshot version
+          uses: xh/hoist-dev-utils/.github/actions/set-validate-snapshot-version@develop
+          with:
+              version: ${{ steps.current-version.outputs.current-version }}
+              append-timestamp: false
 
         - name: Build and publish snapshot to Sonatype
           env:

--- a/.github/workflows/deploySnapshot.yml
+++ b/.github/workflows/deploySnapshot.yml
@@ -17,8 +17,9 @@ on:
                 default: ''
                 type: string
 
+# Debounce builds by branch. Newer runs from a branch will cancel the current run and start over.
 concurrency:
-    group: deploy-snapshot
+    group: deploy-snapshot-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -41,26 +42,11 @@ jobs:
         - name: Setup Gradle
           uses: gradle/actions/setup-gradle@v5
 
-        - name: Override snapshot version in gradle.properties
-          if: inputs.version != ''
-          env:
-              VERSION: ${{ inputs.version }}
-          run: |
-              if [[ ! "$VERSION" == *-SNAPSHOT ]]; then
-                VERSION="$VERSION-SNAPSHOT"
-              fi
-              sed -i "s/^xhReleaseVersion=.*/xhReleaseVersion=$VERSION/" gradle.properties
-              echo "Updated xhReleaseVersion to SNAPSHOT version: $VERSION"
-
-        - name: Read current version from gradle.properties
-          id: current-version
-          run: echo "current-version=$(grep '^xhReleaseVersion=' gradle.properties | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
-
-        - name: Validate snapshot version
-          uses: xh/hoist-dev-utils/.github/actions/set-validate-snapshot-version@develop
+        - name: Prepare snapshot version
+          uses: xh/hoist-dev-utils/.github/actions/prepare-gradle-snapshot-version@master
           with:
-              version: ${{ steps.current-version.outputs.current-version }}
-              append-timestamp: false
+              version: ${{ inputs.version }}
+              version-prop: xhReleaseVersion
 
         - name: Build and publish snapshot to Sonatype
           env:


### PR DESCRIPTION
## Summary
- Replace inline version validation (~70 lines) with shared `validate-release-version` action from `xh/hoist-dev-utils`
- Replace inline tag + GitHub release steps with shared `create-tag-and-github-release` action
- Replace inline snapshot version override + validation with shared `prepare-gradle-snapshot-version` action
- Rename inputs: `xhReleaseVersion` → `version`, `isHotfix` → `is-hotfix`, `xhSnapshotVersion` → `version`
- Add `concurrency: deploy-release` guard to release workflow (serializes releases, never cancels in-progress)
- Change snapshot concurrency group to per-branch (`deploy-snapshot-${{ github.ref }}`) so manual dispatches from other branches don't cancel develop builds
- Add `cache: 'gradle'` to `setup-java` steps

## Dependencies
⚠️ The shared actions in `xh/hoist-dev-utils` must be available on `master` before these workflows can run.

## Test plan
- [ ] Verify shared actions are available on `xh/hoist-dev-utils` `master`
- [ ] Trigger `Deploy Snapshot` via `workflow_dispatch` and verify snapshot publishes to Sonatype
- [ ] Trigger `Deploy Release` on a test branch and verify validation, Sonatype publish, tag, and GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)