### PR TITLE
Add suppressStackTrace and includeStartMessages to LogLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
 
-* Two new columns must be added to the `xh_log_level` table:
+* Two new nullable `Boolean` columns must be added to the `xh_log_level` table:
+  `suppress_stack_trace` and `include_start_messages`. Apps with `dbCreate: update` will have
+  these added automatically. For manually managed schemas, review and run the following SQL,
+  modified as needed for your database:
   ```sql
-  ALTER TABLE xh_log_level ADD suppress_stack_trace BOOLEAN NULL;
-  ALTER TABLE xh_log_level ADD include_start_messages BOOLEAN NULL;
+  ALTER TABLE xh_log_level ADD suppress_stack_trace BIT NULL;
+  ALTER TABLE xh_log_level ADD include_start_messages BIT NULL;
   ```
 
 ### 🎁 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 38.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
+
+* Two new columns must be added to the `xh_log_level` table:
+  ```sql
+  ALTER TABLE xh_log_level ADD suppress_stack_trace BOOLEAN NULL;
+  ALTER TABLE xh_log_level ADD include_start_messages BOOLEAN NULL;
+  ```
+
+### 🎁 New Features
+
+* Added `suppressStackTrace` and `includeStartMessages` fields to `LogLevel` domain, editable
+  via the admin console Log Levels tab. Stacktraces for errors logged via LogSupport are now
+  included by default; set `suppressStackTrace` to `true` to suppress for a logger prefix.
+  Start messages for `withXxx` blocks are off by default; set `includeStartMessages` to `true`
+  to enable. Both support specificity ordering for fine-grained overrides. Replaces the
+  previous TRACE-level gating for stacktraces and finer-level gating for start messages.
+
 ## 37.0.2 - 2026-03-30
 
 ### 🐞 Bug Fixes

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -13,9 +13,9 @@ as the primary interface for all application logging. This design provides sever
   user (when available) and attaches it to the log entry.
 - **Timed execution blocks** -- The `withInfo`, `withDebug`, and `withTrace` methods wrap closures
   with automatic timing, logging both completion status and elapsed time.
-- **Smart exception handling** -- Exceptions passed to log methods produce a concise summary by
-  default. Full stacktraces are only included when the logger is at TRACE level, preventing log
-  spam from recurring errors while preserving diagnostic capability.
+- **Smart exception handling** -- Exceptions passed to log methods produce a concise summary
+  alongside a full stacktrace by default. Admins can suppress stacktraces for noisy logger
+  prefixes via the `suppressStackTrace` field on `LogLevel` entries in the admin console.
 - **Dynamic log levels** -- Log levels can be changed at runtime through the admin console without
   restarting the server, and those changes propagate across all cluster instances.
 - **Built-in log viewer** -- Server logs can be read, searched, and downloaded directly from the
@@ -36,8 +36,8 @@ Every `BaseService` and `BaseController` in a Hoist application automatically im
 | `ClusterInstanceConverter.groovy` | `src/main/groovy/io/xh/hoist/log/` | Logback converter for the `%instance` pattern token; outputs the cluster instance name |
 | `SimpleLogger.groovy` | `src/main/groovy/io/xh/hoist/log/` | Concrete `LogSupport` implementation for logging to an arbitrary named logger |
 | `LogbackConfig.groovy` | `grails-app/init/io/xh/hoist/` | Programmatic Logback configuration with default appenders, layouts, and log levels |
-| `LogLevelService.groovy` | `grails-app/services/io/xh/hoist/log/` | Service managing runtime log level overrides via the `LogLevel` domain class |
-| `LogLevel.groovy` | `grails-app/domain/io/xh/hoist/log/` | GORM domain class persisting log level overrides (table `xh_log_level`) |
+| `LogLevelService.groovy` | `grails-app/services/io/xh/hoist/log/` | Service managing runtime log level overrides and logging flag overrides (`suppressStackTrace`, `includeStartMessages`) via the `LogLevel` domain class |
+| `LogLevel.groovy` | `grails-app/domain/io/xh/hoist/log/` | GORM domain class persisting log level and logging flag overrides (table `xh_log_level`) |
 | `LogReaderService.groovy` | `grails-app/services/io/xh/hoist/log/` | Service providing server-side log file listing, reading, searching, and deletion |
 | `LogArchiveService.groovy` | `grails-app/services/io/xh/hoist/log/` | Service for automatic archival and cleanup of old log files into compressed ZIP bundles |
 | `LogLevelAdminController.groovy` | `grails-app/controllers/io/xh/hoist/admin/` | REST controller for CRUD operations on `LogLevel` domain objects |
@@ -71,8 +71,8 @@ All methods check if the corresponding level is enabled before performing any wo
 cost to leaving log statements in production code at a disabled level.
 
 When an exception is passed as a message argument, `LogSupport` formats it as a concise summary
-(via `ExceptionHandler.summaryTextForThrowable`). A full stacktrace is only appended when the
-logger's effective level is TRACE.
+(via `ExceptionHandler.summaryTextForThrowable`) along with a full stacktrace. Stacktraces can be
+suppressed for specific logger prefixes via `suppressStackTrace` on the `LogLevel` admin entry.
 
 #### Timed execution methods
 
@@ -86,10 +86,9 @@ These methods wrap a closure, automatically logging elapsed time and completion 
 
 Each `withXxx` method:
 
-1. Optionally logs a `started` message at the **same** level as the `withXxx` method, if a finer
-   level is also enabled. Specifically, `withInfo` logs its `started` message at INFO level when
-   DEBUG is enabled; `withDebug` logs its start at DEBUG level when TRACE is enabled. For
-   `withTrace`, the `started` message is always logged (since TRACE is already the finest level).
+1. Optionally logs a `started` message at the **same** level as the `withXxx` method, if
+   `includeStartMessages` is set to `true` on the corresponding `LogLevel` entry in the admin
+   console. This provides a finer-grained view of when logged routines start and end.
 2. Executes the closure and measures elapsed time.
 3. Logs a `completed` message with the elapsed time (e.g., `completed | 342ms`).
 4. If the closure throws, logs a `failed` message with the elapsed time, then re-throws the
@@ -125,8 +124,8 @@ These two classes form the rendering pipeline for `LogSupport` messages:
      (e.g., `[_status: 'completed']` renders as `completed`).
    - The special key `_elapsedMs` is rendered with an `ms` suffix
      (e.g., `[_elapsedMs: 342]` renders as `342ms`).
-   - Throwables are rendered as concise summaries. If the logger is at TRACE level, a full
-     stacktrace is appended.
+   - Throwables are rendered as concise summaries with a full stacktrace by default. Stacktraces
+     can be suppressed per-logger prefix via the `suppressStackTrace` field on `LogLevel` entries.
 
 ### `SimpleLogger`
 
@@ -251,6 +250,19 @@ database table). The admin console provides a UI for this under the "Log Levels"
 Supported levels: `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Inherit` (which removes the
 explicit level and defers to the parent logger), and `Off`.
 
+In addition to log levels, `LogLevel` entries support two nullable boolean flags that control
+logging behavior per logger prefix:
+
+- **`suppressStackTrace`** -- When `true`, suppresses stacktrace output for errors logged via
+  `LogSupport` for the matching logger prefix. Stacktraces are included by default.
+- **`includeStartMessages`** -- When `true`, enables `started` messages for `withInfo`,
+  `withDebug`, and `withTrace` blocks for the matching logger prefix. Start messages are off by
+  default.
+
+Both flags use specificity ordering (longest matching prefix wins) and support `null` (no
+opinion -- defer to a less-specific match), `true`, and `false` (explicitly override a broader
+setting).
+
 ### Log Root Path
 
 The directory where log files are written is determined by `LogbackConfig.getLogRootPath()`:
@@ -302,7 +314,7 @@ Output (at INFO level):
 14:32:05.500 | inst1 | DataSyncService [INFO] | jdoe | Syncing external data | completed | 2340ms
 ```
 
-Output (at DEBUG level -- additional `started` message appears):
+Output (with `includeStartMessages = true` on the LogLevel entry -- additional `started` message):
 ```
 14:32:05.500 | inst1 | DataSyncService [INFO] | jdoe | Syncing external data | started
 14:32:07.840 | inst1 | DataSyncService [INFO] | jdoe | Syncing external data | completed | 2340ms
@@ -333,17 +345,17 @@ try {
 }
 ```
 
-At INFO/DEBUG level -- concise summary:
-```
-14:32:15.200 | inst1 | OrderService [ERROR] | jdoe | Failed to complete operation | orderId=ORD-123 | java.net.ConnectException: Connection refused
-```
-
-At TRACE level -- full stacktrace is appended:
+Default output -- concise summary with full stacktrace:
 ```
 14:32:15.200 | inst1 | OrderService [ERROR] | jdoe | Failed to complete operation | orderId=ORD-123 | java.net.ConnectException: Connection refused
            at java.net.PlainSocketImpl.socketConnect(Native Method)
            at java.net.AbstractPlainSocketImpl.doConnect(...)
            ...
+```
+
+With `suppressStackTrace = true` on a matching LogLevel entry -- concise summary only:
+```
+14:32:15.200 | inst1 | OrderService [ERROR] | jdoe | Failed to complete operation | orderId=ORD-123 | java.net.ConnectException: Connection refused
 ```
 
 ### Using `SimpleLogger` for a dedicated log
@@ -561,12 +573,24 @@ database override for the same logger, the database override will win on the nex
 ### Be mindful of the `StackTrace` logger
 
 Hoist turns off the Grails built-in `StackTrace` logger by default because it can swamp logs in
-production. If you need stacktraces for a specific logger, set that logger to TRACE level instead
--- `LogSupport` will then include full stacktraces for exceptions logged through that logger.
+production. This is separate from Hoist's LogSupport-based stacktrace handling.
+
+### Controlling stacktraces and start messages
+
+Stacktraces for errors logged through `LogSupport` are included by default. To suppress
+stacktraces for a noisy logger, create or edit a `LogLevel` entry in the admin console and set
+`suppressStackTrace` to `true`:
 
 ```groovy
 // In the admin console Log Levels tab:
-// Set io.xh.hoist.mypackage.MyService -> Trace
+// Set io.xh.hoist.mypackage.NoisyService -> suppressStackTrace = true
 //
-// Now any logError/logWarn calls on MyService will include full stacktraces.
+// Now logError/logWarn calls on NoisyService will omit stacktraces.
+// Set a more-specific entry to False to override for a specific subclass.
 ```
+
+Start messages for `withInfo`/`withDebug`/`withTrace` blocks are off by default. To enable them
+for a logger prefix, set `includeStartMessages` to `True` on the `LogLevel` entry.
+
+For external (non-LogSupport) loggers, use `LogbackConfig.suppressStackTrace()` in your
+`LogbackConfig` subclass to filter out noisy stacktraces at the Logback level.

--- a/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
@@ -24,8 +24,17 @@ class LogLevelAdminController extends AdminRestController {
     }
 
     def lookupData() {
-        def levels =  ['None'] + LogLevel.LEVELS
-        renderJSON (levels: levels)
+        def levels = ['None'] + LogLevel.LEVELS,
+            boolFlags = [
+                [value: null, label: 'None'],
+                [value: true, label: 'True'],
+                [value: false, label: 'False']
+            ]
+        renderJSON(
+            levels: levels,
+            suppressStackTraces: boolFlags,
+            includeStartMessages: boolFlags
+        )
     }
 
     protected void doCreate(Object obj, Object data) {

--- a/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
@@ -24,17 +24,7 @@ class LogLevelAdminController extends AdminRestController {
     }
 
     def lookupData() {
-        def levels = ['None'] + LogLevel.LEVELS,
-            boolFlags = [
-                [value: null, label: 'None'],
-                [value: true, label: 'True'],
-                [value: false, label: 'False']
-            ]
-        renderJSON(
-            levels: levels,
-            suppressStackTraces: boolFlags,
-            includeStartMessages: boolFlags
-        )
+        renderJSON(['None'] + LogLevel.LEVELS)
     }
 
     protected void doCreate(Object obj, Object data) {

--- a/grails-app/domain/io/xh/hoist/log/LogLevel.groovy
+++ b/grails-app/domain/io/xh/hoist/log/LogLevel.groovy
@@ -16,6 +16,8 @@ class LogLevel implements JSONFormat {
 
     String name
     String level
+    Boolean suppressStackTrace
+    Boolean includeStartMessages
     Date lastUpdated
     String lastUpdatedBy
 
@@ -34,6 +36,8 @@ class LogLevel implements JSONFormat {
     static constraints = {
         name(unique: true, nullable: false, blank: false)
         level(nullable: true, maxSize: 20, inList: LogLevel.LEVELS)
+        suppressStackTrace(nullable: true)
+        includeStartMessages(nullable: true)
         lastUpdatedBy(nullable: true, maxSize: 50)
     }
 
@@ -51,13 +55,15 @@ class LogLevel implements JSONFormat {
 
     Map formatForJSON() {
         return [
-            id            : id,
-            name          : name,
-            level         : level,
-            defaultLevel  : defaultLevel,
-            effectiveLevel: effectiveLevel,
-            lastUpdated   : lastUpdated,
-            lastUpdatedBy : lastUpdatedBy
+            id                  : id,
+            name                : name,
+            level               : level,
+            suppressStackTrace  : suppressStackTrace,
+            includeStartMessages: includeStartMessages,
+            defaultLevel        : defaultLevel,
+            effectiveLevel      : effectiveLevel,
+            lastUpdated         : lastUpdated,
+            lastUpdatedBy       : lastUpdatedBy
         ]
     }
 

--- a/grails-app/services/io/xh/hoist/log/LogLevelService.groovy
+++ b/grails-app/services/io/xh/hoist/log/LogLevelService.groovy
@@ -8,6 +8,7 @@
 package io.xh.hoist.log
 
 import grails.gorm.transactions.ReadOnly
+import groovy.transform.CompileStatic
 import io.xh.hoist.BaseService
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
@@ -17,9 +18,12 @@ import org.slf4j.LoggerFactory
 import static io.xh.hoist.util.DateTimeUtils.MINUTES
 import static io.xh.hoist.util.ClusterUtils.runOnAllInstances
 
+@CompileStatic
 class LogLevelService extends BaseService {
 
     private List<LogLevelAdjustment> adjustments = []
+    private List<LogFlagOverride> stackTraceOverrides = []
+    private List<LogFlagOverride> startMessageOverrides = []
 
     void init() {
         createTimer(
@@ -38,7 +42,8 @@ class LogLevelService extends BaseService {
     @ReadOnly
     void calculateAdjustments() {
         withDebug('Applying Log Level Adjustments') {
-            def overrides = LogLevel.findAllByLevelIsNotNull()
+            def allLogLevels = LogLevel.list(),
+                overrides = allLogLevels.findAll { it.level != null }
 
             // Remove obsolete log settings if any
             adjustments.each {adj ->
@@ -62,6 +67,10 @@ class LogLevelService extends BaseService {
 
             adjustments = newAdjustments
 
+            // Rebuild flag override lists, sorted by name length desc (most specific first)
+            stackTraceOverrides = buildFlagOverrides(allLogLevels) { LogLevel ll -> ll.suppressStackTrace }
+            startMessageOverrides = buildFlagOverrides(allLogLevels) { LogLevel ll -> ll.includeStartMessages }
+
             logDebug("Adjustments applied: ${adjustments.size()}")
         }
     }
@@ -81,6 +90,24 @@ class LogLevelService extends BaseService {
         return logger.effectiveLevel.toString().toLowerCase().capitalize()
     }
 
+    /**
+     * Check if stacktraces should be suppressed for a given logger name.
+     * Walks the ordered prefix list (most specific first) and returns the first match,
+     * or null if no matching override is configured.
+     */
+    boolean shouldSuppressStackTrace(String loggerName) {
+        return findFlagOverride(stackTraceOverrides, loggerName)
+    }
+
+    /**
+     * Check if start messages should be included for a given logger name.
+     * Walks the ordered prefix list (most specific first) and returns the first match,
+     * or null if no matching override is configured.
+     */
+    boolean shouldIncludeStartMessages(String loggerName) {
+        return findFlagOverride(startMessageOverrides, loggerName)
+    }
+
     void noteLogLevelChanged() {
         runOnAllInstances(this.&calculateAdjustments)
     }
@@ -96,13 +123,29 @@ class LogLevelService extends BaseService {
 
     private void setLogLevel(String logName, String levelStr) {
         def logger = getLogger(logName)
-        logger.level = ('Inherit' == levelStr) ? null : Level[levelStr.toUpperCase()]
+        logger.level = ('Inherit' == levelStr) ? null : Level.toLevel(levelStr)
+    }
+
+    private static boolean findFlagOverride(List<LogFlagOverride> overrides, String loggerName) {
+        overrides.find { loggerName.startsWith(it.prefix) }?.value
+    }
+
+    private static List<LogFlagOverride> buildFlagOverrides(List<LogLevel> logLevels, Closure<Boolean> flagGetter) {
+        logLevels
+            .findAll { flagGetter(it) != null }
+            .collect { new LogFlagOverride(prefix: it.name, value: flagGetter(it)) }
+            .sort { a, b -> b.prefix.length() <=> a.prefix.length() }
     }
 
     private class LogLevelAdjustment {
         String logName
         String defaultLevel
         String adjustedLevel
+    }
+
+    private static class LogFlagOverride {
+        String prefix
+        boolean value
     }
 
     void clearCaches() {

--- a/src/main/groovy/io/xh/hoist/log/LogSupport.groovy
+++ b/src/main/groovy/io/xh/hoist/log/LogSupport.groovy
@@ -18,6 +18,7 @@ import static ch.qos.logback.classic.Level.INFO
 import static ch.qos.logback.classic.Level.DEBUG
 import static ch.qos.logback.classic.Level.TRACE
 import static io.xh.hoist.util.Utils.getIdentityService
+import static io.xh.hoist.util.Utils.getLogLevelService
 import static java.lang.System.currentTimeMillis
 
 @CompileStatic
@@ -26,10 +27,10 @@ trait LogSupport {
     /**
      * Log at INFO level.
      *
-     * If an exception is provided, basic summary info about it will be appended. If effective
-     * logging level is TRACE, a stacktrace will be included as well. This aims to avoid logs being
-     * spammed by recurring / lengthy stacktraces, while still providing a clear indication that an
-     * error occurred plus access to stacktraces when troubleshooting an ongoing situation.
+     * If an exception is provided, basic summary info about it will be appended and a full
+     * stacktrace will be included by default. Admins can suppress stacktraces for specific
+     * logger prefixes by setting `suppressStackTrace = true` on the corresponding LogLevel entry
+     * in the admin console.
      *
      * @param msgs - one or more objects that can be converted into strings
      */
@@ -53,8 +54,9 @@ trait LogSupport {
      * This method will run the passed closure, then log a summary message on INFO indicating the
      * elapsed time to complete and whether the closure threw or completed successfully.
      *
-     * If the configured logging level is TRACE, an additional line will be written BEFORE the
-     * closure is started, providing a finer-grained view on when logged routines start and end.
+     * An additional 'started' message can be enabled by setting `includeStartMessages = true` on
+     * the corresponding LogLevel entry in the admin console, providing a finer-grained view on
+     * when logged routines start and end.
      *
      * @param msgs - one object (typically String, Map, or List) that can be converted into strings.
      * @param c - closure to be run and timed.
@@ -128,9 +130,8 @@ trait LogSupport {
     private <T> T loggedDo(Logger log, Level level, Object msgs, Closure<T> c) {
         Map meta = getMeta() ?: [:];
 
-        // Log *start* of closure execution if at a fine run-time level. Use debug to get
-        // start msgs for your 'withInfo' logs, trace for your 'withDebug/withTrace'
-        if ((log.debugEnabled && level == INFO) || log.traceEnabled) {
+        // Log *start* of closure execution if enabled for this logger via LogLevel admin.
+        if (shouldIncludeStartMessages(log.name)) {
             meta << [_status: 'started']
             logAtLevel(log, level, msgs, meta)
         }
@@ -166,6 +167,14 @@ trait LogSupport {
     private Map getMeta() {
         def username = identityService?.username
         return username ? [_user: username] : null
+    }
+
+    private boolean shouldIncludeStartMessages(String loggerName) {
+        try {
+            return logLevelService?.shouldIncludeStartMessages(loggerName) ?: false
+        } catch (Exception ignored) {
+            return false
+        }
     }
 
     private LogSupportMarker createMarker(Logger log, Object messages, Map meta = getMeta()) {

--- a/src/main/groovy/io/xh/hoist/log/LogSupportConverter.groovy
+++ b/src/main/groovy/io/xh/hoist/log/LogSupportConverter.groovy
@@ -15,6 +15,7 @@ import ch.qos.logback.classic.spi.ThrowableProxy
 import groovy.transform.CompileStatic
 
 import static io.xh.hoist.util.Utils.getExceptionHandler
+import static io.xh.hoist.util.Utils.getLogLevelService
 
 /**
  * Layout Converter to output log messages in a human readable layout.
@@ -55,8 +56,8 @@ class LogSupportConverter extends ClassicConverter {
 
         def ret = parts.join(delimiter)
 
-        // 3) Potentially append stack trace on trace.
-        if (marker.logger.isTraceEnabled() && messages.last() instanceof Throwable) {
+        // 3) Potentially append stack trace for errors with throwables.
+        if (messages.last() instanceof Throwable && !shouldSuppressStackTrace(marker.logger.name)) {
             ret += formatStacktrace(messages.last() as Throwable)
         }
 
@@ -105,6 +106,17 @@ class LogSupportConverter extends ClassicConverter {
             return exceptionHandler.summaryTextForThrowable(t)
         } catch (Exception ignored) {
             return t.message
+        }
+    }
+
+    //---------------------------
+    // Implementation
+    //---------------------------
+    private boolean shouldSuppressStackTrace(String loggerName) {
+        try {
+            return logLevelService?.shouldSuppressStackTrace(loggerName) ?: false
+        } catch (Exception ignored) {
+            return false
         }
     }
 }

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -22,6 +22,7 @@ import io.xh.hoist.exception.ExceptionHandler
 import io.xh.hoist.json.JSONParser
 import io.xh.hoist.json.JSONSerializer
 import io.xh.hoist.ldap.LdapService
+import io.xh.hoist.log.LogLevelService
 import io.xh.hoist.log.LogSupport
 import io.xh.hoist.pref.PrefService
 import io.xh.hoist.role.BaseRoleService
@@ -132,6 +133,10 @@ class Utils {
 
     static LdapService getLdapService() {
         return (LdapService) appContext.ldapService
+    }
+
+    static LogLevelService getLogLevelService() {
+        return (LogLevelService) appContext.logLevelService
     }
 
     static PrefService getPrefService() {


### PR DESCRIPTION
## Summary
- Added `suppressStackTrace` and `includeStartMessages` nullable boolean fields to `LogLevel` domain, editable via the admin console Log Levels tab.
- Stacktraces for errors logged via LogSupport are now included by default; set `suppressStackTrace = true` to suppress for a logger prefix. Replaces TRACE-level gating.
- Start messages for `withXxx` blocks are off by default; set `includeStartMessages = true` to enable. Replaces finer-level gating.
- Both flags use specificity ordering (longest matching prefix wins) with three-state semantics (null/true/false).
- `LogLevelService` maintains ordered override lists, rebuilt on timer and change notification.
- Added `Utils.getLogLevelService()` typed accessor for `@CompileStatic` consumers.
- Updated `docs/logging.md` with new behavior documentation.

## Breaking
Two new columns required on `xh_log_level`:
```sql
ALTER TABLE xh_log_level ADD suppress_stack_trace BOOLEAN NULL;
ALTER TABLE xh_log_level ADD include_start_messages BOOLEAN NULL;
```

## Test plan
- [x] Verify `./gradlew clean assemble` passes
- [x] Deploy and confirm new fields appear in Log Levels admin dialog
- [x] Create a LogLevel entry with `suppressStackTrace = true` and verify stacktraces are suppressed for that logger prefix
- [ ] Create a LogLevel entry with `includeStartMessages = true` and verify start messages appear for `withXxx` blocks
- [ ] Verify specificity ordering: more-specific prefix overrides broader setting
- [ ] Verify cluster propagation via `noteLogLevelChanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)