### PR TITLE
Add MCP resource support for doc downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 38.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* Added MCP resource support for full document downloads via `hoist-core://docs/{docId}` URIs, enabling AI coding agents to read complete documentation content in addition to keyword search.
+
 ## 37.0.2 - 2026-03-30
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 38.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fixed MCP server not invalidating its cached GitHub source archive for branch refs (e.g. `develop`), causing documentation to become stale over time. Branch caches are now re-downloaded after 24 hours; tag and SHA refs remain cached indefinitely.
+
 ### ⚙️ Technical
 
 * Added MCP resource support for full document downloads via `hoist-core://docs/{docId}` URIs, enabling AI coding agents to read complete documentation content in addition to keyword search.

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/GitHubContentSource.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/GitHubContentSource.groovy
@@ -14,10 +14,17 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
  * ContentSource backed by a downloaded GitHub tarball, cached locally.
  * Downloads the hoist-core repo at a specific ref (tag, branch, or SHA)
  * and extracts it to ~/.cache/hoist-core-mcp/<ref>/.
+ *
+ * For branch refs (e.g. "develop"), the cache is invalidated after {@link #MAX_CACHE_AGE_MS}
+ * to ensure documentation stays in sync with the latest source. Tag and SHA refs are
+ * considered immutable and cached indefinitely.
  */
 class GitHubContentSource implements ContentSource {
 
     private static final String GITHUB_API = 'https://api.github.com/repos/xh/hoist-core/tarball'
+
+    /** Max age for branch caches before re-download. Tags/SHAs are cached indefinitely. */
+    private static final long MAX_CACHE_AGE_MS = 24 * 60 * 60 * 1000  // 24 hours
 
     final String ref
     final File cacheDir
@@ -68,14 +75,18 @@ class GitHubContentSource implements ContentSource {
     }
 
     /**
-     * Download and extract the tarball if not already cached.
+     * Download and extract the tarball if not already cached (or if the cache is stale).
      * Returns the extracted directory root (the single top-level dir in the tarball).
      */
     private File ensureDownloaded() {
-        // Check if already cached — look for a single directory inside cacheDir
         if (cacheDir.isDirectory()) {
-            def extracted = findExtractedRoot()
-            if (extracted) return extracted
+            if (isCacheStale()) {
+                McpLog.info("Cache for '${ref}' is stale (>${MAX_CACHE_AGE_MS / 3600000}h old), re-downloading...")
+                cacheDir.deleteDir()
+            } else {
+                def extracted = findExtractedRoot()
+                if (extracted) return extracted
+            }
         }
 
         McpLog.info("Downloading hoist-core archive for ref '${ref}'...")
@@ -134,5 +145,20 @@ class GitHubContentSource implements ContentSource {
             }
         }
         return null
+    }
+
+    /**
+     * Check if the cache is stale. Branch refs (e.g. "develop") are invalidated after
+     * MAX_CACHE_AGE_MS. Tag refs (e.g. "v37.0.0") and SHA refs are immutable and never stale.
+     */
+    private boolean isCacheStale() {
+        if (isImmutableRef()) return false
+        def age = System.currentTimeMillis() - cacheDir.lastModified()
+        return age > MAX_CACHE_AGE_MS
+    }
+
+    /** Tags (v1.2.3) and full SHAs (40 hex chars) point to immutable content. */
+    private boolean isImmutableRef() {
+        return ref.startsWith('v') || ref.matches('[0-9a-f]{40}')
     }
 }

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/HoistCoreMcpServer.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/HoistCoreMcpServer.groovy
@@ -7,6 +7,7 @@ import io.modelcontextprotocol.server.transport.StdioServerTransportProvider
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities
 import io.xh.hoist.mcp.data.DocRegistry
 import io.xh.hoist.mcp.data.GroovyRegistry
+import io.xh.hoist.mcp.resources.DocResources
 import io.xh.hoist.mcp.tools.DocTools
 import io.xh.hoist.mcp.tools.GroovyTools
 import io.xh.hoist.mcp.util.McpLog
@@ -63,6 +64,7 @@ class HoistCoreMcpServer {
         def groovyRegistry = new GroovyRegistry(contentSource)
 
         def toolSpecs = DocTools.create(docRegistry) + GroovyTools.create(groovyRegistry)
+        def resourceSpecs = DocResources.create(docRegistry)
 
         def transportProvider = new StdioServerTransportProvider(McpJsonDefaults.getMapper())
 
@@ -71,9 +73,11 @@ class HoistCoreMcpServer {
             .instructions('Hoist Core MCP server — provides access to hoist-core framework documentation and Groovy/Java symbol information.')
             .capabilities(ServerCapabilities.builder()
                 .tools(true)
+                .resources(false, false)
                 .build()
             )
             .tools(toolSpecs)
+            .resources(resourceSpecs)
             .build()
 
         // Warm the Groovy symbol index in the background so the first tool call doesn't

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/resources/DocResources.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/resources/DocResources.groovy
@@ -1,0 +1,42 @@
+package io.xh.hoist.mcp.resources
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult
+import io.modelcontextprotocol.spec.McpSchema.Resource
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents
+import io.xh.hoist.mcp.data.DocRegistry
+import io.xh.hoist.mcp.util.McpLog
+
+/**
+ * Creates documentation resource specifications for the MCP server.
+ *
+ * Registers each document in the DocRegistry as an MCP resource, allowing
+ * clients to read full document content via `hoist-core://docs/{docId}` URIs.
+ */
+class DocResources {
+
+    static List<SyncResourceSpecification> create(DocRegistry registry) {
+        def specs = registry.entries.collect { entry ->
+            def resource = Resource.builder()
+                .uri("hoist-core://docs/${entry.id}")
+                .name(entry.title)
+                .title('Hoist Core Documentation')
+                .description(entry.description)
+                .mimeType('text/markdown')
+                .build()
+
+            new SyncResourceSpecification(resource, { exchange, request ->
+                def content = registry.loadContent(entry.id)
+                if (!content) {
+                    throw new RuntimeException("Document not found: ${entry.id}")
+                }
+                new ReadResourceResult([
+                    new TextResourceContents(request.uri(), 'text/markdown', content)
+                ])
+            })
+        }
+
+        McpLog.info("Registered ${specs.size()} doc resources via hoist-core://docs/{docId}")
+        return specs
+    }
+}


### PR DESCRIPTION
## Summary

* Added MCP resource support so AI coding agents can download full documentation content via `hoist-core://docs/{docId}` URIs, complementing the existing keyword search tools.
* New `DocResources` class registers each doc in the `DocRegistry` as an MCP resource.
* Added changelog entry under `38.0-SNAPSHOT`.
* Also closes https://github.com/xh/hoist-core/issues/533

## Test plan

- [ ] Verify MCP server starts and `hoist-core-list-docs` still works
- [ ] Verify `ListMcpResourcesTool` returns all 25 docs
- [ ] Verify `ReadMcpResourceTool` can fetch each doc's full content

🤖 Generated with [Claude Code](https://claude.com/claude-code)