### PR TITLE
Bug fix and enhance new flag fields in LogLevel

### DIFF
--- a/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
@@ -17,14 +17,17 @@ class LogLevelAdminController extends AdminRestController {
     def logLevelService
 
     protected void preprocessSubmit(Map submit) {
-        if (submit.level == 'None') {
-            submit.level = null
-        }
         submit.lastUpdatedBy = authUsername
     }
 
     def lookupData() {
-        renderJSON(['None'] + LogLevel.LEVELS)
+        renderJSON(
+            // This is a vanilla hoist-react SelectOption[], which hoist rest model and select automatically accepts.
+            levels: [
+                [label: 'None', value: null],
+                *LogLevel.LEVELS.collect { [label: it, value: it] }
+            ]
+        )
     }
 
     protected void doCreate(Object obj, Object data) {

--- a/grails-app/domain/io/xh/hoist/log/LogLevel.groovy
+++ b/grails-app/domain/io/xh/hoist/log/LogLevel.groovy
@@ -25,6 +25,10 @@ class LogLevel implements JSONFormat {
 
     String getEffectiveLevel() { logLevelService.getEffectiveLevel(name) }
 
+    Boolean getEffectiveSuppressStackTrace() { logLevelService.shouldSuppressStackTrace(name) }
+
+    Boolean getEffectiveIncludeStartMessages() { logLevelService.shouldIncludeStartMessages(name) }
+
     public static List<String> LEVELS = ['Trace', 'Debug', 'Info', 'Warn', 'Error', 'Inherit', 'Off']
 
     static mapping = {
@@ -55,15 +59,17 @@ class LogLevel implements JSONFormat {
 
     Map formatForJSON() {
         return [
-            id                  : id,
-            name                : name,
-            level               : level,
-            suppressStackTrace  : suppressStackTrace,
-            includeStartMessages: includeStartMessages,
-            defaultLevel        : defaultLevel,
-            effectiveLevel      : effectiveLevel,
-            lastUpdated         : lastUpdated,
-            lastUpdatedBy       : lastUpdatedBy
+            id                           : id,
+            name                         : name,
+            level                        : level,
+            suppressStackTrace           : suppressStackTrace,
+            includeStartMessages         : includeStartMessages,
+            defaultLevel                 : defaultLevel,
+            effectiveLevel               : effectiveLevel,
+            effectiveSuppressStackTrace  : effectiveSuppressStackTrace,
+            effectiveIncludeStartMessages: effectiveIncludeStartMessages,
+            lastUpdated                  : lastUpdated,
+            lastUpdatedBy                : lastUpdatedBy
         ]
     }
 


### PR DESCRIPTION
## Summary
- Add `effectiveSuppressStackTrace` and `effectiveIncludeStartMessages` computed properties to `LogLevel`, resolving the prefix-based flag inheritance so the client gets the actual applied values alongside the raw configured values.
- Fix `LogLevelAdminController.lookupData()` to return the lookupData for the 'levels' key expected by frontend. Also enhanced it to `SelectOption[]` format with proper null value handling, removing the now-unnecessary `preprocessSubmit` workaround for 'None'.

## Test plan
- [x] Verify LogLevel admin panel displays effective flag values for each logger
- [x] Set `suppressStackTrace` on a parent logger (e.g. `io.xh.hoist`) and confirm child loggers show `effectiveSuppressStackTrace: true`
- [x] Set a more specific override (e.g. `io.xh.hoist.config` with `suppressStackTrace: false`) and confirm it wins over the parent
- [x] Same tests for `includeStartMessages`
- [x] Verify level dropdown still works correctly with null/"None" and "Inherit" options

🤖 Generated with [Claude Code](https://claude.com/claude-code)