### PR TITLE
Add rule-based span sampling to TraceService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 🎁 New Features
 
-* Added rule-based span sampling to `TraceService` via new `samplingRules` and `alwaysSampleErrors` options in `xhTraceConfig`. Rules match span tags with glob patterns to set per-span sample rates, and error spans can be force-exported regardless of sampling.
+* Added rule-based span sampling to `TraceService` via new `sampleRules` and `alwaysSampleErrors` options in `xhTraceConfig`. Rules match span tags with glob patterns to set per-span sample rates, and error spans can be force-exported regardless of sampling.
 * Apps can now customize OTEL resource attributes by overriding `getOtelResourceAttributes()` on
   their `ClusterConfig` subclass. These attributes are applied to both traces and metrics
   exporters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🎁 New Features
 
+* Added rule-based span sampling to `TraceService` via new `samplingRules` and `alwaysSampleErrors` options in `xhTraceConfig`. Rules match span tags with glob patterns to set per-span sample rates, and error spans can be force-exported regardless of sampling.
 * Apps can now customize OTEL resource attributes via the `xhOtelResourceAttributes` soft config
   key. Attributes set here are merged with Hoist's defaults and applied to both traces and
   metrics exporters.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -322,7 +322,7 @@ Non-string values (numbers, booleans) use strict equality.
    entries all match produces the `sampleRate` for a probabilistic decision.
 4. Unmatched spans use the fallback `sampleRate`.
 5. Unsampled spans are recorded but not exported — unless they end in error and
-   `alwaysSampleErrors` is enabled, in which case a dedicated `SpanProcessor` force-exports them.
+   `alwaysSampleErrors` is enabled, in which case `HoistBatchSpanProcessor` promotes them to sampled and exports them through the normal batch pipeline.
 
 The client-side `TraceService` in hoist-react evaluates the same `samplingRules` config, so
 sampling decisions are consistent across client and server spans.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -26,7 +26,11 @@ delegate to no-op implementations, so no null checks are needed in application c
 - **Thread context propagation** — Grails `task {}` calls automatically carry the current trace
   context to worker threads via `ContextPropagatingPromiseFactory`.
 - **Client span relay** — Browser-generated spans are submitted to `xh/submitSpans` and exported
-  through the same server-side pipeline, producing end-to-end client-to-server traces.
+  through the same server-side pipeline, producing end-to-end client-to-server traces. Client
+  spans are pre-sampled in the browser — only sampled or error spans are relayed.
+- **Rule-based sampling** — Configurable `samplingRules` match span tags (with glob patterns) to
+  determine per-span sample rates. Error spans can be force-exported regardless of sampling via
+  `alwaysSampleErrors`.
 - **Log correlation** — `traceId` is captured on log markers when inside a traced context,
   enabling log-to-trace correlation.
 
@@ -214,7 +218,7 @@ ObservedRun.observe(this)
 |----------|-------|
 | **Type** | `json` |
 | **Default** | See below |
-| **Client Visible** | Yes (client reads `enabled` and `sampleRate` for browser tracing) |
+| **Client Visible** | Yes (client reads `enabled`, `sampleRate`, `samplingRules`, and `alwaysSampleErrors` for browser tracing) |
 | **Purpose** | Distributed tracing infrastructure configuration. |
 
 **Default value:**
@@ -223,6 +227,8 @@ ObservedRun.observe(this)
 {
     "enabled": false,
     "sampleRate": 1.0,
+    "samplingRules": [],
+    "alwaysSampleErrors": true,
     "otlpEnabled": false,
     "otlpConfig": {}
 }
@@ -231,7 +237,9 @@ ObservedRun.observe(this)
 | Key | Type | Description |
 |-----|------|-------------|
 | `enabled` | Boolean | Master switch for tracing. When false, all tracing is no-op. Dynamic. |
-| `sampleRate` | Double | Sampling rate from 0.0 to 1.0. Uses a deterministic trace-ID-based algorithm. Dynamic. |
+| `sampleRate` | Double | Fallback sampling rate (0.0–1.0) applied when no sampling rule matches. Dynamic. |
+| `samplingRules` | List\<Map\> | Ordered rules for per-span sampling. Each rule has a `match` map of tag patterns and a `sampleRate`. First match wins; unmatched spans use the fallback `sampleRate`. See [Sampling Rules](#sampling-rules) below. Dynamic. |
+| `alwaysSampleErrors` | Boolean | When true (default), spans that end in error are exported even if unsampled. Dynamic. |
 | `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. |
 | `otlpConfig` | Map | OTLP exporter config (e.g. `{"endpoint": "http://localhost:4318/v1/traces"}`). |
 
@@ -263,6 +271,61 @@ When `otlpEnabled: true`, spans are exported via HTTP/protobuf to an OTLP-compat
 
 Applications can register additional exporters via `traceService.addExporter()`. These
 receive both server-generated and client-relayed spans.
+
+---
+
+## Sampling Rules
+
+Sampling rules provide fine-grained, tag-based control over which spans are sampled. Rules are
+evaluated at span creation time (head-based sampling) on both client and server. Each rule has a
+`match` map of tag patterns and a `sampleRate` — the first matching rule wins.
+
+### Configuration
+
+Add rules to the `samplingRules` array in `xhTraceConfig`:
+
+```json
+{
+    "enabled": true,
+    "sampleRate": 0.1,
+    "samplingRules": [
+        {"match": {"name": "GET health/*"}, "sampleRate": 0},
+        {"match": {"xh.source": "hoist"}, "sampleRate": 0.01},
+        {"match": {"user.name": "jsmith"}, "sampleRate": 1.0}
+    ],
+    "alwaysSampleErrors": true
+}
+```
+
+In this example: health-check spans are dropped entirely, framework-generated spans are sampled at
+1%, spans from user `jsmith` are always sampled, and everything else falls back to the 10% default.
+
+### Pattern matching
+
+String tag values support simple glob patterns:
+
+| Pattern | Matches |
+|---------|---------|
+| `*` | Any value |
+| `foo*` | Values starting with `foo` |
+| `*foo` | Values ending with `foo` |
+| `*foo*` | Values containing `foo` |
+| `foo` | Exact match |
+
+Non-string values (numbers, booleans) use strict equality.
+
+### Sampling flow
+
+1. Tags are assembled on the span before the sampling decision.
+2. If a valid sampled parent context exists, the child inherits the parent's decision.
+3. Otherwise, `samplingRules` are evaluated against the span's tags. The first rule whose `match`
+   entries all match produces the `sampleRate` for a probabilistic decision.
+4. Unmatched spans use the fallback `sampleRate`.
+5. Unsampled spans are recorded but not exported — unless they end in error and
+   `alwaysSampleErrors` is enabled, in which case a dedicated `SpanProcessor` force-exports them.
+
+The client-side `TraceService` in hoist-react evaluates the same `samplingRules` config, so
+sampling decisions are consistent across client and server spans.
 
 ---
 
@@ -336,8 +399,8 @@ Browser-generated spans are batched and posted to the `xh/submitSpans` endpoint.
 trace/span IDs — and exports them through the same pipeline as server-generated spans. This
 means client and server spans appear as a coherent distributed trace in the collector.
 
-The same deterministic trace-ID-based sampling is applied to client spans, ensuring consistent
-sampling decisions across the full trace.
+Client spans are pre-sampled in the browser using the shared `samplingRules` config — only
+sampled spans (and error spans when `alwaysSampleErrors` is enabled) are relayed to the server.
 
 ---
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -28,7 +28,7 @@ delegate to no-op implementations, so no null checks are needed in application c
 - **Client span relay** — Browser-generated spans are submitted to `xh/submitSpans` and exported
   through the same server-side pipeline, producing end-to-end client-to-server traces. Client
   spans are pre-sampled in the browser — only sampled or error spans are relayed.
-- **Rule-based sampling** — Configurable `samplingRules` match span tags (with glob patterns) to
+- **Rule-based sampling** — Configurable `sampleRules` match span tags (with glob patterns) to
   determine per-span sample rates. Error spans can be force-exported regardless of sampling via
   `alwaysSampleErrors`.
 - **Log correlation** — `traceId` is captured on log markers when inside a traced context,
@@ -218,7 +218,7 @@ ObservedRun.observe(this)
 |----------|-------|
 | **Type** | `json` |
 | **Default** | See below |
-| **Client Visible** | Yes (client reads `enabled`, `sampleRate`, `samplingRules`, and `alwaysSampleErrors` for browser tracing) |
+| **Client Visible** | Yes (client reads `enabled`, `sampleRate`, `sampleRules`, and `alwaysSampleErrors` for browser tracing) |
 | **Purpose** | Distributed tracing infrastructure configuration. |
 
 **Default value:**
@@ -227,7 +227,7 @@ ObservedRun.observe(this)
 {
     "enabled": false,
     "sampleRate": 1.0,
-    "samplingRules": [],
+    "sampleRules": [],
     "alwaysSampleErrors": true,
     "otlpEnabled": false,
     "otlpConfig": {}
@@ -238,7 +238,7 @@ ObservedRun.observe(this)
 |-----|------|-------------|
 | `enabled` | Boolean | Master switch for tracing. When false, all tracing is no-op. Dynamic. |
 | `sampleRate` | Double | Fallback sampling rate (0.0–1.0) applied when no sampling rule matches. Dynamic. |
-| `samplingRules` | List\<Map\> | Ordered rules for per-span sampling. Each rule has a `match` map of tag patterns and a `sampleRate`. First match wins; unmatched spans use the fallback `sampleRate`. See [Sampling Rules](#sampling-rules) below. Dynamic. |
+| `sampleRules` | List\<Map\> | Ordered rules for per-span sampling. Each rule has a `match` map of tag patterns and a `sampleRate`. First match wins; unmatched spans use the fallback `sampleRate`. See [Sampling Rules](#sampling-rules) below. Dynamic. |
 | `alwaysSampleErrors` | Boolean | When true (default), spans that end in error are exported even if unsampled. Dynamic. |
 | `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. |
 | `otlpConfig` | Map | OTLP exporter config (e.g. `{"endpoint": "http://localhost:4318/v1/traces"}`). |
@@ -282,13 +282,13 @@ evaluated at span creation time (head-based sampling) on both client and server.
 
 ### Configuration
 
-Add rules to the `samplingRules` array in `xhTraceConfig`:
+Add rules to the `sampleRules` array in `xhTraceConfig`:
 
 ```json
 {
     "enabled": true,
     "sampleRate": 0.1,
-    "samplingRules": [
+    "sampleRules": [
         {"match": {"name": "GET health/*"}, "sampleRate": 0},
         {"match": {"xh.source": "hoist"}, "sampleRate": 0.01},
         {"match": {"user.name": "jsmith"}, "sampleRate": 1.0}
@@ -318,13 +318,13 @@ Non-string values (numbers, booleans) use strict equality.
 
 1. Tags are assembled on the span before the sampling decision.
 2. If a valid sampled parent context exists, the child inherits the parent's decision.
-3. Otherwise, `samplingRules` are evaluated against the span's tags. The first rule whose `match`
+3. Otherwise, `sampleRules` are evaluated against the span's tags. The first rule whose `match`
    entries all match produces the `sampleRate` for a probabilistic decision.
 4. Unmatched spans use the fallback `sampleRate`.
 5. Unsampled spans are recorded but not exported — unless they end in error and
    `alwaysSampleErrors` is enabled, in which case `HoistBatchSpanProcessor` promotes them to sampled and exports them through the normal batch pipeline.
 
-The client-side `TraceService` in hoist-react evaluates the same `samplingRules` config, so
+The client-side `TraceService` in hoist-react evaluates the same `sampleRules` config, so
 sampling decisions are consistent across client and server spans.
 
 ---
@@ -399,7 +399,7 @@ Browser-generated spans are batched and posted to the `xh/submitSpans` endpoint.
 trace/span IDs — and exports them through the same pipeline as server-generated spans. This
 means client and server spans appear as a coherent distributed trace in the collector.
 
-Client spans are pre-sampled in the browser using the shared `samplingRules` config — only
+Client spans are pre-sampled in the browser using the shared `sampleRules` config — only
 sampled spans (and error spans when `alwaysSampleErrors` is enabled) are relayed to the server.
 
 ---

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -326,7 +326,7 @@ class BootStrap implements LogSupport {
                 defaultValue: [
                     enabled: false,
                     sampleRate: 1.0,
-                    samplingRules: [],
+                    sampleRules: [],
                     alwaysSampleErrors: true,
                     otlpEnabled: false,
                     otlpConfig: [:]

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -326,6 +326,8 @@ class BootStrap implements LogSupport {
                 defaultValue: [
                     enabled: false,
                     sampleRate: 1.0,
+                    samplingRules: [],
+                    alwaysSampleErrors: true,
                     otlpEnabled: false,
                     otlpConfig: [:]
                 ],

--- a/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
@@ -126,7 +126,7 @@ class TraceService extends BaseService {
         if (!sdk) return null
 
         // Build complete tag set
-        tags = new HashMap(tags)
+        tags = new HashMap<String, ?>(tags)
         if (!tags['xh.source']) tags['xh.source'] = 'app'
         if (caller) tags['code.namespace'] = caller.class.name
         if (username) tags['user.name'] = username

--- a/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
@@ -21,16 +21,10 @@ import io.opentelemetry.context.propagation.TextMapSetter
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
-import io.opentelemetry.sdk.trace.ReadableSpan
-import io.opentelemetry.sdk.trace.ReadWriteSpan
-import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import io.opentelemetry.sdk.trace.export.SpanExporter
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.api.trace.StatusCode
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.ConfigService
 import jakarta.servlet.http.HttpServletRequest
@@ -144,10 +138,16 @@ class TraceService extends BaseService {
         def spanBuilder = sdk.getTracer('io.xh.hoist')
             .spanBuilder(name)
             .setSpanKind(kind)
-            .setAttribute('sampleRate', getSampleRate(tags)),
-            span = spanBuilder.startSpan()
+            .setAttribute('sampleRate', getSampleRate(tags))
 
-        return new SpanRef(spanBuilder.startSpan(), span.makeCurrent(), kind)
+        tags.each { k, v ->
+            if (v instanceof String) spanBuilder.setAttribute(k as String, v)
+            else if (v instanceof Number) spanBuilder.setAttribute(k as String, ((Number) v).doubleValue())
+            else if (v instanceof Boolean) spanBuilder.setAttribute(k as String, (boolean) v)
+        }
+
+        def span = spanBuilder.startSpan()
+        return new SpanRef(span, span.makeCurrent(), kind)
     }
 
     //-------------
@@ -268,7 +268,7 @@ class TraceService extends BaseService {
             if (!config.enabled) return
 
             def attrsBuilder = Attributes.builder()
-            otelResourceAttributes.each { k, v -> attrsBuilder.put(stringKey(k), v) }
+            otelResourceAttributes.each { k, v -> attrsBuilder.put(AttributeKey.stringKey(k), v) }
             _resource = Resource.default.merge(Resource.create(attrsBuilder.build()))
 
             _samplingRules = config.samplingRules ?: []
@@ -298,14 +298,8 @@ class TraceService extends BaseService {
                 _otlpExporter = null
             }
 
-            // BatchSpanProcessor handles normally-sampled spans.
             eachExporter {SpanExporter e ->
-                providerBuilder.addSpanProcessor(BatchSpanProcessor.builder(e).build())
-            }
-
-            // Error override processor force-exports recordOnly spans that ended in error.
-            if (config.alwaysSampleErrors) {
-                providerBuilder.addSpanProcessor(errorOverrideProcessor())
+                providerBuilder.addSpanProcessor(new HoistBatchSpanProcessor(e, config.alwaysSampleErrors))
             }
 
             _otelSdk = OpenTelemetrySdk.builder()
@@ -326,11 +320,6 @@ class TraceService extends BaseService {
         _otelSdk = null
         _resource = null
     }
-
-    private AttributeKey stringKey(String str) {
-        AttributeKey.stringKey(str)
-    }
-
 
     //--------------------------------------------------
     // Lifecycle
@@ -355,6 +344,7 @@ class TraceService extends BaseService {
             Iterable<String> keys(HttpServletRequest carrier) {
                 Collections.list(carrier.headerNames)
             }
+
             String get(HttpServletRequest carrier, String key) {
                 carrier.getHeader(key)
             }
@@ -382,6 +372,7 @@ class TraceService extends BaseService {
             Iterable<String> keys(Map<String, String> carrier) {
                 carrier?.keySet() ?: Collections.emptySet() as Iterable<String>
             }
+
             String get(Map<String, String> carrier, String key) {
                 carrier?.get(key)
             }
@@ -392,7 +383,7 @@ class TraceService extends BaseService {
      * Sampler that evaluates {@code samplingRules} against span attributes.
      * Defers to parent sampling decision when a valid parent context exists,
      * using {@code recordOnly()} for unsampled parents to preserve spans for
-     * the error override processor.
+     * {@link HoistBatchSpanProcessor}'s error promotion.
      */
     private final Sampler _sampler = new Sampler() {
         SamplingResult shouldSample(
@@ -409,7 +400,7 @@ class TraceService extends BaseService {
                 SamplingResult.recordOnly()
         }
 
-        String getDescription() { return 'Hoist Sampler'}
+        String getDescription() {return 'Hoist Sampler'}
     }
 
     /**
@@ -450,30 +441,4 @@ class TraceService extends BaseService {
         if (endsWithWild) return actualStr.startsWith(core)
         return actual == pattern
     }
-
-    /**
-     * SpanProcessor that force-exports unsampled spans that end in error when
-     * {@code alwaysSampleErrors} is enabled. Added to the provider alongside the
-     * standard {@link BatchSpanProcessor} — it only acts on {@code recordOnly} spans
-     * (those the sampler deemed unsampled) that completed with an error status.
-     */
-    private SpanProcessor errorOverrideProcessor() {
-        def svc = this
-        return new SpanProcessor() {
-            void onStart(Context parentContext, ReadWriteSpan span) {}
-            boolean isStartRequired() { false }
-            boolean isEndRequired() { true }
-
-            void onEnd(ReadableSpan span) {
-                if (span.spanContext.isSampled()) return
-                if (span.toSpanData().status.statusCode != StatusCode.ERROR) return
-                def data = Collections.singletonList(span.toSpanData())
-                svc.eachExporter { SpanExporter e -> e.export(data) }
-            }
-
-            CompletableResultCode shutdown() { CompletableResultCode.ofSuccess() }
-            CompletableResultCode forceFlush() { CompletableResultCode.ofSuccess() }
-        }
-    }
-
 }

--- a/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
@@ -61,7 +61,7 @@ class TraceService extends BaseService {
     private OpenTelemetrySdk _otelSdk
     private SpanExporter _otlpExporter
     private Resource _resource
-    private List<Map> _samplingRules = []
+    private List<Map> _sampleRules = []
     private double _sampleRate = 1.0
     private final HoistSampler _sampler = new HoistSampler()
 
@@ -267,7 +267,7 @@ class TraceService extends BaseService {
             otelResourceAttributes.each { k, v -> attrsBuilder.put(AttributeKey.stringKey(k), v) }
             _resource = Resource.default.merge(Resource.create(attrsBuilder.build()))
 
-            _samplingRules = config.samplingRules ?: []
+            _sampleRules = config.sampleRules ?: []
             _sampleRate = config.sampleRate.toDouble()
 
             def providerBuilder = SdkTracerProvider.builder()
@@ -381,9 +381,9 @@ class TraceService extends BaseService {
      */
     private double getSampleRate(Map tags) {
         try {
-            if (!_samplingRules) return _sampleRate
+            if (!_sampleRules) return _sampleRate
 
-            for (Map rule in _samplingRules) {
+            for (Map rule in _sampleRules) {
                 if (rule.match?.every { k, v -> matchesValue(tags[k], v) } &&
                     rule.sampleRate instanceof Number
                 ) {

--- a/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
@@ -22,16 +22,12 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.ConfigService
 import jakarta.servlet.http.HttpServletRequest
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
-
-import io.opentelemetry.sdk.trace.samplers.SamplingResult
-
 import io.opentelemetry.api.common.AttributeKey
 import grails.async.Promises
 
@@ -67,10 +63,10 @@ class TraceService extends BaseService {
     private Resource _resource
     private List<Map> _samplingRules = []
     private double _sampleRate = 1.0
+    private final HoistSampler _sampler = new HoistSampler()
 
 
     void init() {
-        def registry = metricsService.registry
         installContextPropagation()
         syncConfig()
     }
@@ -129,8 +125,8 @@ class TraceService extends BaseService {
         def sdk = _otelSdk
         if (!sdk) return null
 
-        // Build complete tag set and set on builder so the sampler can evaluate rules.
-        tags = new LinkedHashMap<String, Object>(tags)
+        // Build complete tag set
+        tags = new HashMap(tags)
         if (!tags['xh.source']) tags['xh.source'] = 'app'
         if (caller) tags['code.namespace'] = caller.class.name
         if (username) tags['user.name'] = username
@@ -138,16 +134,16 @@ class TraceService extends BaseService {
         def spanBuilder = sdk.getTracer('io.xh.hoist')
             .spanBuilder(name)
             .setSpanKind(kind)
-            .setAttribute('sampleRate', getSampleRate(tags))
 
-        tags.each { k, v ->
-            if (v instanceof String) spanBuilder.setAttribute(k as String, v)
-            else if (v instanceof Number) spanBuilder.setAttribute(k as String, ((Number) v).doubleValue())
-            else if (v instanceof Boolean) spanBuilder.setAttribute(k as String, (boolean) v)
+        try {
+            _sampler.setSampleRate(getSampleRate(tags))
+            def span = spanBuilder.startSpan(),
+                ret = new SpanRef(span, span.makeCurrent(), kind)
+            ret.setTags(tags)
+            return ret
+        } finally {
+            _sampler.clearSampleRate()
         }
-
-        def span = spanBuilder.startSpan()
-        return new SpanRef(span, span.makeCurrent(), kind)
     }
 
     //-------------
@@ -378,30 +374,6 @@ class TraceService extends BaseService {
             }
         }
 
-
-    /**
-     * Sampler that evaluates {@code samplingRules} against span attributes.
-     * Defers to parent sampling decision when a valid parent context exists,
-     * using {@code recordOnly()} for unsampled parents to preserve spans for
-     * {@link HoistBatchSpanProcessor}'s error promotion.
-     */
-    private final Sampler _sampler = new Sampler() {
-        SamplingResult shouldSample(
-            Context ctx,
-            String traceId,
-            String name,
-            SpanKind kind,
-            Attributes attrs,
-            List parentLinks
-        ) {
-            def parent = Span.fromContext(ctx).spanContext
-            return ((parent.isValid() && parent.isSampled()) || Math.random() < attrs.get(AttributeKey.doubleKey('sampleRate'))) ?
-                SamplingResult.recordAndSample() :
-                SamplingResult.recordOnly()
-        }
-
-        String getDescription() {return 'Hoist Sampler'}
-    }
 
     /**
      * Evaluate sampling rules against span attributes. Returns the sample rate from the first

--- a/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
@@ -4,7 +4,6 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-
 package io.xh.hoist.telemetry
 
 import groovy.transform.CompileStatic
@@ -22,17 +21,22 @@ import io.opentelemetry.context.propagation.TextMapSetter
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.samplers.Sampler
-import io.opentelemetry.sdk.trace.samplers.SamplingResult
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import io.opentelemetry.sdk.trace.export.SpanExporter
-import io.micrometer.core.instrument.Counter
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.api.trace.StatusCode
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.ConfigService
 import jakarta.servlet.http.HttpServletRequest
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
+
+import io.opentelemetry.sdk.trace.samplers.SamplingResult
 
 import io.opentelemetry.api.common.AttributeKey
 import grails.async.Promises
@@ -67,20 +71,12 @@ class TraceService extends BaseService {
     private OpenTelemetrySdk _otelSdk
     private SpanExporter _otlpExporter
     private Resource _resource
+    private List<Map> _samplingRules = []
     private double _sampleRate = 1.0
-    private Counter _spansRequested
-    private Counter _spansCreated
 
 
     void init() {
         def registry = metricsService.registry
-        _spansRequested = Counter.builder('hoist.trace.spans.requested')
-            .description('Total spans evaluated for sampling — includes server and client-relayed spans')
-            .register(registry)
-        _spansCreated = Counter.builder('hoist.trace.spans.created')
-            .description('Total spans that passed sampling — includes server and client-relayed spans')
-            .register(registry)
-
         installContextPropagation()
         syncConfig()
     }
@@ -139,18 +135,20 @@ class TraceService extends BaseService {
         def sdk = _otelSdk
         if (!sdk) return null
 
-        def spanBuilder = sdk.getTracer('io.xh.hoist').spanBuilder(name).setSpanKind(kind),
-            span = spanBuilder.startSpan(),
-            pending = new SpanRef(span, span.makeCurrent(), kind)
+        // Build complete tag set and set on builder so the sampler can evaluate rules.
+        tags = new LinkedHashMap<String, Object>(tags)
+        if (!tags['xh.source']) tags['xh.source'] = 'app'
+        if (caller) tags['code.namespace'] = caller.class.name
+        if (username) tags['user.name'] = username
 
-        pending.setTags(tags)
-        if (!tags['xh.source']) pending.setTag('xh.source', 'app')
-        if (caller) pending.setTag('code.namespace', caller.class.name)
-        if (username) pending.setTag('user.name', username)
+        def spanBuilder = sdk.getTracer('io.xh.hoist')
+            .spanBuilder(name)
+            .setSpanKind(kind)
+            .setAttribute('sampleRate', getSampleRate(tags)),
+            span = spanBuilder.startSpan()
 
-        return pending
+        return new SpanRef(spanBuilder.startSpan(), span.makeCurrent(), kind)
     }
-
 
     //-------------
     // Misc
@@ -227,60 +225,22 @@ class TraceService extends BaseService {
     // Framework-internal
     //--------------------------------------------------
     /**
-     * Submit client-side spans received from the browse.
+     * Submit client-side spans received from the browser.
      *
-     * Converts the client span JSON into OTel {@link io.opentelemetry.sdk.trace.data.SpanData} objects and exports them
-     * through the configured export pipeline, preserving the original trace/span IDs so
-     * that client and server spans form a coherent distributed trace.
+     * Converts the client span JSON into OTel {@link io.opentelemetry.sdk.trace.data.SpanData}
+     * objects and exports them through the configured export pipeline.
      *
-     * Spans are filtered using the same deterministic trace-ID-based sampling as
-     * server-originated spans, ensuring consistent sampling across both paths.
+     * Client spans are pre-sampled by the client -- only exportable (i.e. sampled spans or error spans)
+     * are expected here.
      *
      * @param spans - list of span maps as serialized by the client {@code Span.toJSON()}
      */
     void submitClientSpans(List<Map> spans) {
         def resource = _resource
         if (!resource) return
-
-        def data = spans
-            .findAll { shouldSample(it.traceId as String) }
-            .collect { new ClientSpanData(it, resource) } as List<SpanData>
-
-        eachExporter { SpanExporter e ->
-            e.export(data)
-        }
+        def data = spans.collect { new ClientSpanData(it, resource) } as List<SpanData>
+        eachExporter {SpanExporter e -> e.export(data)}
     }
-
-
-    /**
-     * Determine if a trace should be sampled based on its trace ID.
-     *
-     * Uses the same deterministic algorithm as the OTel {@code traceIdRatioBased} sampler:
-     * the lower 8 bytes of the trace ID are compared against a threshold derived from the
-     * configured sample rate. Re-implemented here to allow consistent sampling decisions
-     * across both server-originated spans and client-relayed spans.
-     *
-     * @internal
-     */
-    boolean shouldSample(String traceId) {
-        _spansRequested?.increment()
-        boolean ret
-        if (_sampleRate >= 1.0) {
-            ret = true
-        } else if (_sampleRate <= 0.0) {
-            ret = false
-        } else {
-            try {
-                long lowerLong = Long.parseUnsignedLong(traceId.substring(16), 16)
-                ret = Long.compareUnsigned(lowerLong, (long) (Long.MAX_VALUE * _sampleRate)) < 0
-            } catch (Exception ignored) {
-                ret = false
-            }
-        }
-        if (ret) _spansCreated?.increment()
-        return ret
-    }
-
 
     //--------------------------------------------------
     // Implementation
@@ -311,7 +271,8 @@ class TraceService extends BaseService {
             otelResourceAttributes.each { k, v -> attrsBuilder.put(stringKey(k), v) }
             _resource = Resource.default.merge(Resource.create(attrsBuilder.build()))
 
-            _sampleRate = config.sampleRate
+            _samplingRules = config.samplingRules ?: []
+            _sampleRate = config.sampleRate.toDouble()
 
             def providerBuilder = SdkTracerProvider.builder()
                 .setResource(_resource)
@@ -337,9 +298,14 @@ class TraceService extends BaseService {
                 _otlpExporter = null
             }
 
-            // Add all exporters
+            // BatchSpanProcessor handles normally-sampled spans.
             eachExporter {SpanExporter e ->
                 providerBuilder.addSpanProcessor(BatchSpanProcessor.builder(e).build())
+            }
+
+            // Error override processor force-exports recordOnly spans that ended in error.
+            if (config.alwaysSampleErrors) {
+                providerBuilder.addSpanProcessor(errorOverrideProcessor())
             }
 
             _otelSdk = OpenTelemetrySdk.builder()
@@ -380,9 +346,7 @@ class TraceService extends BaseService {
     }
 
     Map getAdminStats() {[
-        config: configForAdminStats('xhTraceConfig'),
-        spansRequested: _spansRequested?.count(),
-        spansCreated: _spansCreated?.count()
+        config: configForAdminStats('xhTraceConfig')
     ]}
 
     /** Shared getter for extracting trace context from incoming servlet requests. */
@@ -423,7 +387,13 @@ class TraceService extends BaseService {
             }
         }
 
-    /** Sampler using {@link #shouldSample} — shared by the SDK pipeline and client span relay. */
+
+    /**
+     * Sampler that evaluates {@code samplingRules} against span attributes.
+     * Defers to parent sampling decision when a valid parent context exists,
+     * using {@code recordOnly()} for unsampled parents to preserve spans for
+     * the error override processor.
+     */
     private final Sampler _sampler = new Sampler() {
         SamplingResult shouldSample(
             Context ctx,
@@ -433,9 +403,77 @@ class TraceService extends BaseService {
             Attributes attrs,
             List parentLinks
         ) {
-            TraceService.this.shouldSample(traceId) ? SamplingResult.recordAndSample() : SamplingResult.drop()
+            def parent = Span.fromContext(ctx).spanContext
+            return ((parent.isValid() && parent.isSampled()) || Math.random() < attrs.get(AttributeKey.doubleKey('sampleRate'))) ?
+                SamplingResult.recordAndSample() :
+                SamplingResult.recordOnly()
         }
-        String getDescription() { "HoistTraceIdRatio(${_sampleRate})" }
+
+        String getDescription() { return 'Hoist Sampler'}
+    }
+
+    /**
+     * Evaluate sampling rules against span attributes. Returns the sample rate from the first
+     * matching rule, or the configured fallback rate if no rule matches.
+     */
+    private double getSampleRate(Map tags) {
+        try {
+            if (!_samplingRules) return _sampleRate
+
+            for (Map rule in _samplingRules) {
+                if (rule.match?.every { k, v -> matchesValue(tags[k], v) } &&
+                    rule.sampleRate instanceof Number
+                ) {
+                    return ((Number) rule.sampleRate).doubleValue()
+                }
+            }
+            return _sampleRate
+        } catch (Exception e) {
+            logError("Failed to compute sample rate", e)
+            return 0d
+        }
+    }
+
+    /** For strings, Simple glob matching: {@code *} = any, {@code foo*} = prefix, {@code *foo} = suffix. */
+    private boolean matchesValue(Object actual, Object pattern) {
+        if (!(actual instanceof String) || !(pattern instanceof String)) return actual == pattern
+        def patternStr = pattern as String,
+            actualStr = actual as String
+
+        if (patternStr == '*') return true
+        def startsWithWild = patternStr.startsWith('*'),
+            endsWithWild = patternStr.endsWith('*'),
+            core = patternStr.replaceAll('^\\*|\\*\$', '')
+
+        if (startsWithWild && endsWithWild) return actualStr.contains(core)
+        if (startsWithWild) return actualStr.endsWith(core)
+        if (endsWithWild) return actualStr.startsWith(core)
+        return actual == pattern
+    }
+
+    /**
+     * SpanProcessor that force-exports unsampled spans that end in error when
+     * {@code alwaysSampleErrors} is enabled. Added to the provider alongside the
+     * standard {@link BatchSpanProcessor} — it only acts on {@code recordOnly} spans
+     * (those the sampler deemed unsampled) that completed with an error status.
+     */
+    private SpanProcessor errorOverrideProcessor() {
+        def svc = this
+        return new SpanProcessor() {
+            void onStart(Context parentContext, ReadWriteSpan span) {}
+            boolean isStartRequired() { false }
+            boolean isEndRequired() { true }
+
+            void onEnd(ReadableSpan span) {
+                if (span.spanContext.isSampled()) return
+                if (span.toSpanData().status.statusCode != StatusCode.ERROR) return
+                def data = Collections.singletonList(span.toSpanData())
+                svc.eachExporter { SpanExporter e -> e.export(data) }
+            }
+
+            CompletableResultCode shutdown() { CompletableResultCode.ofSuccess() }
+            CompletableResultCode forceFlush() { CompletableResultCode.ofSuccess() }
+        }
     }
 
 }

--- a/src/main/groovy/io/xh/hoist/telemetry/HoistBatchSpanProcessor.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/HoistBatchSpanProcessor.groovy
@@ -1,0 +1,84 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+package io.xh.hoist.telemetry
+
+import groovy.transform.CompileStatic
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import io.opentelemetry.sdk.trace.export.SpanExporter
+
+/**
+ * SpanProcessor that delegates to a {@link BatchSpanProcessor} and optionally promotes
+ * unsampled error spans so they get batched and exported.
+ *
+ * {@code BatchSpanProcessor.onEnd()} rejects spans where {@code isSampled()} is false.
+ * When {@code alwaysSampleErrors} is enabled in the trace config, this processor wraps
+ * recordOnly spans that ended in error with a {@link PromotedErrorSpan} that flips the
+ * sampled flag, allowing them through the gate and into the batch queue.
+ */
+@CompileStatic
+class HoistBatchSpanProcessor implements SpanProcessor {
+
+    private final BatchSpanProcessor batch
+    private boolean alwaysSampleErrors
+
+    HoistBatchSpanProcessor(SpanExporter exporter, boolean alwaysSampleErrors) {
+        this.batch = BatchSpanProcessor.builder(exporter).build()
+        this.alwaysSampleErrors = alwaysSampleErrors
+    }
+
+    void onStart(Context ctx, ReadWriteSpan span) { batch.onStart(ctx, span) }
+
+    boolean isStartRequired() { batch.isStartRequired() }
+
+    boolean isEndRequired() { true }
+
+    void onEnd(ReadableSpan span) {
+        if (alwaysSampleErrors &&
+            !span.spanContext.isSampled() &&
+            span.toSpanData().status.statusCode == StatusCode.ERROR
+        ) {
+            span = new PromotedErrorSpan(span)
+        }
+        batch.onEnd(span)
+    }
+
+    CompletableResultCode shutdown() { batch.shutdown() }
+
+    CompletableResultCode forceFlush() { batch.forceFlush() }
+
+    /**
+     * Wraps a ReadableSpan, overriding getSpanContext() to return a sampled version.
+     * This lets BatchSpanProcessor accept spans that were originally recordOnly.
+     */
+    @CompileStatic
+    private static class PromotedErrorSpan implements ReadableSpan {
+        @Delegate(excludes = ['getSpanContext'])
+        private final ReadableSpan delegate
+
+        private final SpanContext promotedContext
+
+        PromotedErrorSpan(ReadableSpan span) {
+            this.delegate = span
+            def ctx = span.spanContext
+            this.promotedContext = SpanContext.create(
+                ctx.traceId, ctx.spanId,
+                TraceFlags.sampled, ctx.traceState
+            )
+        }
+
+        @Override
+        SpanContext getSpanContext() { promotedContext }
+    }
+}

--- a/src/main/groovy/io/xh/hoist/telemetry/HoistSampler.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/HoistSampler.groovy
@@ -46,9 +46,14 @@ class HoistSampler implements Sampler {
         Attributes attrs,
         List parentLinks
     ) {
-        def parent = Span.fromContext(ctx).spanContext,
-            rate = _sampleRate.get() ?: 0d
-        return ((parent.isValid() && parent.isSampled()) || Math.random() < rate) ?
+        def parent = Span.fromContext(ctx).spanContext
+        if (parent.isValid()) {
+            return parent.isSampled() ?
+                SamplingResult.recordAndSample() :
+                SamplingResult.recordOnly()
+        }
+        def rate = _sampleRate.get() ?: 0d
+        return Math.random() < rate ?
             SamplingResult.recordAndSample() :
             SamplingResult.recordOnly()
     }

--- a/src/main/groovy/io/xh/hoist/telemetry/HoistSampler.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/HoistSampler.groovy
@@ -1,0 +1,58 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+package io.xh.hoist.telemetry
+
+import groovy.transform.CompileStatic
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.samplers.Sampler
+import io.opentelemetry.sdk.trace.samplers.SamplingResult
+
+/**
+ * OTel {@link Sampler} that applies a per-span sample rate set via a thread-local.
+ *
+ * Callers set the rate with {@link #setSampleRate} before {@code startSpan()} and
+ * clear it afterwards. Inherits a sampled parent's decision. Returns
+ * {@code recordOnly()} (not {@code drop()}) for unsampled spans so that
+ * {@link HoistBatchSpanProcessor} can still promote error spans.
+ */
+@CompileStatic
+class HoistSampler implements Sampler {
+
+    private final ThreadLocal<Double> _sampleRate = new ThreadLocal<>()
+
+    /** Set the sample rate for the next span to be created on the current thread. */
+    void setSampleRate(double rate) {
+        _sampleRate.set(rate)
+    }
+
+    /** Clear the thread-local sample rate after span creation. */
+    void clearSampleRate() {
+        _sampleRate.remove()
+    }
+
+    @Override
+    SamplingResult shouldSample(
+        Context ctx,
+        String traceId,
+        String name,
+        SpanKind kind,
+        Attributes attrs,
+        List parentLinks
+    ) {
+        def parent = Span.fromContext(ctx).spanContext,
+            rate = _sampleRate.get() ?: 0d
+        return ((parent.isValid() && parent.isSampled()) || Math.random() < rate) ?
+            SamplingResult.recordAndSample() :
+            SamplingResult.recordOnly()
+    }
+
+    @Override
+    String getDescription() { return 'HoistSampler' }
+}

--- a/src/main/groovy/io/xh/hoist/telemetry/TraceConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/TraceConfig.groovy
@@ -20,7 +20,7 @@ class TraceConfig extends TypedConfigMap {
     Map otlpConfig
 
     /** Ordered tag-match rules for sampling. First match wins. */
-    List<Map> samplingRules = []
+    List<Map> sampleRules = []
 
     /** Always export error spans, bypassing sample-rate filtering. Defaults to true. */
     boolean alwaysSampleErrors = true

--- a/src/main/groovy/io/xh/hoist/telemetry/TraceConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/TraceConfig.groovy
@@ -22,9 +22,6 @@ class TraceConfig extends TypedConfigMap {
     /** Ordered tag-match rules for sampling. First match wins. */
     List<Map> samplingRules = []
 
-    /** Fallback sample rate (0–1) when no sampling rule matches. */
-    double defaultSampleRate = 1.0
-
     /** Always export error spans, bypassing sample-rate filtering. Defaults to true. */
     boolean alwaysSampleErrors = true
 }

--- a/src/main/groovy/io/xh/hoist/telemetry/TraceConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/TraceConfig.groovy
@@ -18,4 +18,13 @@ class TraceConfig extends TypedConfigMap {
     double sampleRate
     boolean otlpEnabled
     Map otlpConfig
+
+    /** Ordered tag-match rules for sampling. First match wins. */
+    List<Map> samplingRules = []
+
+    /** Fallback sample rate (0–1) when no sampling rule matches. */
+    double defaultSampleRate = 1.0
+
+    /** Always export error spans, bypassing sample-rate filtering. Defaults to true. */
+    boolean alwaysSampleErrors = true
 }


### PR DESCRIPTION
## Summary

* Added `sampleRules` and `alwaysSampleErrors` options to `xhTraceConfig` for fine-grained, tag-based control over which spans are sampled.
* Rules match span tags with glob patterns to set per-span sample rates. Error spans can be force-exported regardless of sampling.
* Client spans are now pre-sampled in the browser — the server relay no longer re-evaluates sampling.

**Companion PR:** xh/hoist-react#4328 — client-side sampling rule evaluation using the shared `sampleRules` config. Must be merged together.

## Test plan

- [ ] Verify default config (no rules) samples at the configured `sampleRate`
- [ ] Add sampling rules and confirm first-match-wins behavior
- [ ] Confirm error spans are exported when `alwaysSampleErrors: true`, even if unsampled
- [ ] Verify child spans inherit parent sampling decision
- [ ] Confirm `traceparent` header carries correct sampled flag

🤖 Generated with Claude Opus 4.6