### PR TITLE
Always pass a non-null SpanRef to withSpan closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * **JDK 25 support** — hoist-core now builds on JDK 25 while continuing to ship a JAR that runs on JDK 17+
   (see ⚙️ Technical for the toolchain/bytecode-target contract).
+* `TraceService.withSpan` (and `ObservedRun.run`) now always pass a non-null `SpanRef` to the
+  closure — a shared no-op `SpanRef.NOOP` is used when tracing is disabled, eliminating the need
+  for `?.` null-safe calls on the span.
 
 ### 📚 Libraries
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -62,7 +62,8 @@ the primary span creation API.
 
 Execute a closure within a new trace span. Creates a child span if a parent context exists, or a
 root span otherwise. Exceptions are recorded on the span and re-thrown. The closure may optionally
-accept a `SpanRef` parameter (null when tracing is disabled).
+accept a `SpanRef` parameter, which may be further enhanced with tags, or information about errors.
+Note that a NoOp span is passed even if tracing is disabled.
 
 For combined tracing + logging + metrics, use `ObservedRun` via `BaseService.observe()` instead.
 
@@ -78,7 +79,7 @@ For combined tracing + logging + metrics, use `ObservedRun` via `BaseService.obs
 ```groovy
 traceService.withSpan(name: 'fetchData', kind: SpanKind.CLIENT, tags: [url: endpoint]) { SpanRef span ->
     def result = httpClient.get(endpoint)
-    span?.setHttpStatus(result.statusCode)
+    span.setHttpStatus(result.statusCode)
     result
 }
 ```
@@ -192,7 +193,7 @@ observe()
     .span(name: 'processOrder', tags: [orderId: id])
     .run { SpanRef span ->
         def result = doWork()
-        span?.setTag('resultCount', result.size())
+        span.setTag('resultCount', result.size())
         result
     }
 ```

--- a/grails-app/services/io/xh/hoist/http/BaseProxyService.groovy
+++ b/grails-app/services/io/xh/hoist/http/BaseProxyService.groovy
@@ -91,7 +91,7 @@ abstract class BaseProxyService extends BaseService {
                 traceService.injectContext(method)
                 try (CloseableHttpResponse sourceResponse = sourceClient.execute(method)) {
                     response.setStatus(sourceResponse.code)
-                    span?.setHttpStatus(sourceResponse.code)
+                    span.setHttpStatus(sourceResponse.code)
                     installResponseHeaders(response, sourceResponse)
 
                     sourceResponse.entity?.writeTo(response.outputStream)

--- a/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/TraceService.groovy
@@ -86,18 +86,21 @@ class TraceService extends BaseService {
      * Creates a child span under the current context. Exceptions are recorded on the span and
      * re-thrown. See {@link #createSpan} for parameter documentation.
      *
+     * The closure is always passed a non-null {@link SpanRef} — when tracing is disabled, a
+     * shared no-op object is provided so callers never need to null-check.
+     *
      * For combined tracing + logging + metrics, use {@link ObservedRun} via
      * {@link BaseService#observe()}.
      */
     <T> T withSpan(Map args, Closure<T> c) {
-        SpanRef span = createSpan(args.subMap(['name', 'kind', 'tags', 'caller']))
+        SpanRef span = createSpan(args.subMap(['name', 'kind', 'tags', 'caller'])) ?: SpanRef.NOOP
         try {
             return c.maximumNumberOfParameters > 0 ? c.call(span) : c.call()
         } catch (Throwable t) {
-            span?.recordException(t)
+            span.recordException(t)
             throw t
         } finally {
-            span?.close()
+            span.close()
         }
     }
 

--- a/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
+++ b/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
@@ -161,7 +161,7 @@ class JSONClient {
             .run { SpanRef span ->
                 traceService.injectContext(method)
                 def ret = client.execute(method)
-                span?.setHttpStatus(ret.code)
+                span.setHttpStatus(ret.code)
                 ret
             }
     }

--- a/src/main/groovy/io/xh/hoist/telemetry/ObservedRun.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/ObservedRun.groovy
@@ -50,7 +50,7 @@ class ObservedRun {
 
     // Span support
     private Map spanArgs //map matching TraceService.createSpan args
-    private SpanRef activeSpan
+    private SpanRef activeSpan = SpanRef.NOOP
 
     // Metrics support
     private Timer timer

--- a/src/main/groovy/io/xh/hoist/telemetry/SpanRef.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/SpanRef.groovy
@@ -27,6 +27,14 @@ import io.opentelemetry.context.Scope
  */
 @CompileStatic
 class SpanRef implements Closeable {
+
+    /**
+     * No-op SpanRef used when tracing is disabled — all methods are safe to call and
+     * do nothing. Returned by {@link TraceService#withSpan} so closures can always
+     * rely on a non-null span.
+     */
+    static final SpanRef NOOP = new SpanRef(Span.invalid, Scope.noop(), SpanKind.INTERNAL)
+
     final Span span
     final Scope scope
     final SpanKind kind


### PR DESCRIPTION
## Summary

- `TraceService.withSpan` now supplies a shared `SpanRef.NOOP` (backed by `Span.invalid` / `Scope.noop()`) when tracing is disabled, so closures always receive a non-null `SpanRef`.
- Removes the need for `?.` null-safe calls on `span` at every instrumented call site — updated `JSONClient`, `BaseProxyService`, docs, and examples.
- `ObservedRun.run` carries the same non-null guarantee via `activeSpan = SpanRef.NOOP` default.

## Test plan

- [ ] `./gradlew assemble` (compileGroovy passes locally).
- [ ] Exercise a traced code path with tracing disabled and confirm `span.setTag` / `span.setHttpStatus` are safe no-ops.
- [ ] Exercise the same path with `xhTraceConfig.enabled = true` and confirm spans export normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)