### PR TITLE
Add tailSamplingEnabled flag to xhTraceConfig

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -223,6 +223,7 @@ ObservedRun.observe(this)
 ```json
 {
     "enabled": false,
+    "tailSamplingEnabled": true,
     "sampleRate": 1.0,
     "sampleRules": [],
     "traceTimeoutMs": 300000,
@@ -236,10 +237,11 @@ ObservedRun.observe(this)
 | Key | Type | Description |
 |-----|------|-------------|
 | `enabled` | Boolean | Master switch for tracing. When false, all tracing is no-op. Dynamic. |
-| `sampleRate` | Double | Fallback per-trace sampling rate (0.0–1.0) applied when no rule matches the root span. Error traces always export regardless. Dynamic. |
-| `sampleRules` | List\<Map\> | Ordered rules matched against the **root span** of each trace. Each rule has a `match` map of tag patterns (plus the reserved `name` key that matches the span's name) and a `sampleRate`. First match wins; unmatched traces use the fallback `sampleRate`. See [Sampling Rules](#sampling-rules) below. Dynamic. |
-| `traceTimeoutMs` | Long | Silence threshold before an abandoned trace buffer is force-evicted. Not a trace-duration cap — long-running traces that stay active flush normally when their root ends. Defaults to `300000` (5 minutes). Dynamic. |
-| `maxBufferedTraces` | Integer | Cap on in-flight traces buffered by the tail sampler. New traces past the cap are dropped with a WARN log until pressure eases. Defaults to `10000`. Dynamic. |
+| `tailSamplingEnabled` | Boolean | When true (default), server and client spans flow through Hoist's per-trace tail-sampling buffer and the keep/drop decision is made server-side. When false, spans are exported as they complete and `sampleRate`/`sampleRules`/`traceTimeoutMs`/`maxBufferedTraces` are unused — sampling is delegated to downstream infrastructure (e.g. an OTel Collector). Dynamic. See [Sampling](#sampling) below. |
+| `sampleRate` | Double | Fallback per-trace sampling rate (0.0–1.0) applied when no rule matches the root span. Error traces always export regardless. Ignored when `tailSamplingEnabled` is false. Dynamic. |
+| `sampleRules` | List\<Map\> | Ordered rules matched against the **root span** of each trace. Each rule has a `match` map of tag patterns (plus the reserved `name` key that matches the span's name) and a `sampleRate`. First match wins; unmatched traces use the fallback `sampleRate`. Ignored when `tailSamplingEnabled` is false. See [Sampling Rules](#sampling-rules) below. Dynamic. |
+| `traceTimeoutMs` | Long | Silence threshold before an abandoned trace buffer is force-evicted. Not a trace-duration cap — long-running traces that stay active flush normally when their root ends. Ignored when `tailSamplingEnabled` is false. Defaults to `300000` (5 minutes). Dynamic. |
+| `maxBufferedTraces` | Integer | Cap on in-flight traces buffered by the tail sampler. New traces past the cap are dropped with a WARN log until pressure eases. Ignored when `tailSamplingEnabled` is false. Defaults to `10000`. Dynamic. |
 | `jdbcTracingEnabled` | Boolean | Emit CLIENT spans for all JDBC `DataSource` operations — applies to every pool (primary + any additional Grails datasources). Defaults to `false`. Dynamic. See [JDBC](#outbound-jdbc) below. |
 | `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. Gated by the `suppressOtlpExport` instance config (defaults to `'true'` in local dev, `'false'` otherwise). |
 | `otlpConfig` | Map | OTLP exporter config (e.g. `{"endpoint": "http://localhost:4318/v1/traces"}`). |
@@ -287,6 +289,15 @@ the entire trace. This has two consequences application developers should know:
 - **Sample rules apply at the trace level.** Rules match the root span's name and tags — not
   individual spans within the trace. This is more intuitive: you're asking "should we keep this
   request's trace?" rather than deciding span-by-span.
+
+### Pass-through mode
+
+Setting `tailSamplingEnabled: false` bypasses the buffer entirely. Server and client spans are
+handed directly to the export pipeline as they complete, and all sampling-related config
+(`sampleRate`, `sampleRules`, `traceTimeoutMs`, `maxBufferedTraces`) is ignored. Use this mode
+when a downstream OTel Collector (or equivalent) owns the keep/drop decision — the application
+simply produces and exports every recorded span. Inbound W3C `sampled=0` is still honored, so
+upstream drop decisions continue to propagate.
 
 ### Propagation semantics
 

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -330,6 +330,7 @@ class BootStrap implements LogSupport {
                 valueType: 'json',
                 defaultValue: [
                     enabled: false,
+                    tailSamplingEnabled: true,
                     sampleRate: 1.0,
                     sampleRules: [],
                     traceTimeoutMs: 300000,

--- a/grails-app/services/io/xh/hoist/telemetry/trace/impl/SpanProcessingService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/trace/impl/SpanProcessingService.groovy
@@ -67,12 +67,17 @@ class SpanProcessingService extends BaseService implements SpanProcessor {
     //-----------------------------------
     /**
      * Accept client-submitted spans: wrap as {@link ClientSpanData} (with server-stamped
-     * common attrs) and merge into the same per-traceId buffer as server spans.
+     * common attrs) and merge into the same per-traceId buffer as server spans. When tail
+     * sampling is disabled, hand spans straight to the export pipeline instead.
      */
     void submitClientSpans(List<Map> spans, Resource resource) {
         def extras = commonAttrs()
-        spans.each { Map raw ->
-            def span = new ClientSpanData(raw, resource, extras)
+        def wrapped = spans.collect { Map raw -> new ClientSpanData(raw, resource, extras) }
+        if (!config.tailSamplingEnabled) {
+            Utils.traceService.exportSpans(wrapped as List<ReadableSpan>)
+            return
+        }
+        wrapped.each { span ->
             def buffer = getOrCreateBuffer(span.spanContext.traceId)
             buffer?.addSpan(span)
         }
@@ -100,6 +105,7 @@ class SpanProcessingService extends BaseService implements SpanProcessor {
 
     void onStart(Context ctx, ReadWriteSpan span) {
         commonAttrs().each { k, v -> setAttr(span, k, v) }
+        if (!config.tailSamplingEnabled) return
         def buffer = getOrCreateBuffer(span.spanContext.traceId)
         if (buffer) {
             // Record the root early so the sweeper can tell "open root" from "no root arrived."
@@ -109,6 +115,10 @@ class SpanProcessingService extends BaseService implements SpanProcessor {
     }
 
     void onEnd(ReadableSpan span) {
+        if (!config.tailSamplingEnabled) {
+            Utils.traceService.exportSpans([span])
+            return
+        }
         def buffer = _buffers.get(span.spanContext.traceId)
         buffer?.addSpan(span)
     }
@@ -128,6 +138,16 @@ class SpanProcessingService extends BaseService implements SpanProcessor {
     //-----------------------------------
     void sweep() {
         def cfg = config
+        // Drain any leftover buffers immediately if tail sampling has been turned off.
+        // Pass-through mode means "export everything," so skip the keep/drop roll.
+        if (!cfg.tailSamplingEnabled) {
+            _buffers.values().each { buffer ->
+                if (_buffers.remove(buffer.traceId, buffer)) {
+                    Utils.traceService.exportSpans(buffer.drainSpans())
+                }
+            }
+            return
+        }
         def timeoutCutoff = System.currentTimeMillis() - cfg.traceTimeoutMs,
             laggingParentCutoff = System.currentTimeMillis() - LAGGING_PARENT_MS
         _buffers.values().each { TraceBuffer buffer ->

--- a/src/main/groovy/io/xh/hoist/telemetry/trace/TraceConfig.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/trace/TraceConfig.groovy
@@ -17,6 +17,14 @@ class TraceConfig extends TypedConfigMap {
     boolean otlpEnabled
     Map otlpConfig
 
+    /**
+     * Master switch for the tail-sampling buffer. When false, server and client spans are
+     * handed straight to the export pipeline as they complete — `sampleRate`, `sampleRules`,
+     * `traceTimeoutMs`, and `maxBufferedTraces` are all unused and sampling is effectively
+     * deferred to downstream (e.g. an OTel Collector). Defaults to true.
+     */
+    boolean tailSamplingEnabled = true
+
     /** Ordered match rules for per-trace sampling. Evaluated against the root span. First match wins. */
     List<Map> sampleRules = []
 


### PR DESCRIPTION
## Summary

Proposes adding a `tailSamplingEnabled` flag to `xhTraceConfig` as an opt-out for the tail-sampling buffer introduced on the parent branch. When set to `false`, `SpanProcessingService` hands each completed server and client span directly to the export pipeline as it finishes, and `sampleRate` / `sampleRules` / `traceTimeoutMs` / `maxBufferedTraces` are ignored. Sampling is then effectively delegated to whatever infrastructure the operator runs downstream (e.g. an OTel Collector).

Defaults to `true`, preserving the current branch's behavior exactly.

## Motivation

A couple of operational modes currently available through `xhTraceConfig` already approximate pass-through by setting `sampleRate: 1.0` with no rules — every trace ends up kept — but spans still accumulate in the per-trace buffer until the root ends, and the `MAX_SPANS_PER_TRACE` (500) and `maxBufferedTraces` (10k) caps still apply. For deployments that want the simpler "record and export as you go" shape and rely on a collector for keep/drop decisions, this flag makes that an explicit first-class mode rather than an emergent side effect of the config.

It also leaves a clean, well-labeled seam: operators who don't want Hoist making sampling decisions at all can disable it in one knob, without losing any of the other instrumentation (`onStart` attribute stamping, W3C propagation, JDBC tracing, OTLP export, client-span relay).

## What changes

- **`TraceConfig`**: new `boolean tailSamplingEnabled = true` field.
- **`BootStrap`**: new key added to the default `xhTraceConfig` value.
- **`SpanProcessingService`**:
  - `onStart` still stamps common attributes in both modes.
  - `onEnd` short-circuits to `traceService.exportSpans([span])` when the flag is off.
  - `submitClientSpans` short-circuits the same way for browser-relayed spans.
  - `sweep` drains any leftover buffers unconditionally on a live flip from `true` → `false`, rather than rolling them against the now-superseded sample rate.
- **`docs/tracing.md`**: new config row, new "Pass-through mode" subsection under Sampling.

## What stays the same

- `ParentBased(AlwaysOn)` sampler is unchanged. Inbound W3C `sampled=0` still drops locally, and outbound `traceparent` still carries `sampled=1` while recording.
- All span attribute stamping (`user.name`, `xh.isPrimary`, `xh.impersonating`, `xh.fromHoistClient`, HTTP semantic-convention attrs from `HoistFilter`) runs in both modes.
- `ClientSpanData` / client span relay still merges client and server spans by traceId into a single trace in the backend (via direct export in pass-through mode, via the tail buffer otherwise).
- `BatchSpanProcessor` handling of each registered exporter is unchanged.

## Trade-offs worth calling out for review

- **Default value.** Chose `true` to preserve current branch behavior exactly. If we'd rather make the simpler mode the default, it's a one-line change.
- **Live flip behavior.** Flipping `true` → `false` drains any in-flight buffers on the next `sweep` tick (≤5s) and exports them unconditionally. Flipping `false` → `true` just starts buffering new traces from that point; no retroactive behavior.
- **Admin stats.** `bufferedTraces` reads `0` when the flag is off — self-documenting, no extra field needed.

## Test plan

- [ ] Enable tracing with `tailSamplingEnabled: true` (default); confirm existing behavior unchanged — traces buffer and flush on root end, error traces kept in full, sample rules applied at root.
- [ ] Flip to `tailSamplingEnabled: false` at runtime; confirm `bufferedTraces` drains within one sweep interval and new spans export individually as they complete.
- [ ] In pass-through mode, confirm browser-submitted spans still appear alongside their server counterparts in the backend (same traceId).
- [ ] In pass-through mode, confirm inbound `traceparent` with `sampled=0` still drops locally (no spans recorded).
- [ ] In pass-through mode, confirm outbound `JSONClient` calls still carry `traceparent` with `sampled=1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B694STHxPV4xurGXeFotAe)_