### PR TITLE
Trace ergonomics: BaseService.span() shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
       include authentication and routing time, and skip noisy requests like 'ping' and web sockets.
     * New span tags `xh.isPrimary` and `xh.impersonating`. `user.name` now refers to the
       *authenticated* user.
+    * New `BaseService.span(name, kind?, tags?)` shortcut for the common case of starting an
+      `ObservedRun` with an initial span — equivalent to `observe().span(...)`.
 * OTLP export (metrics and traces) is now suppressed by default while running in local
   development. Set the new `otlpEnabledInLocalDev` instance config to `'true'` to opt in. In local
   dev, exports tag `deployment.environment.name` with the OS username (e.g. `Development-johndoe`)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -238,7 +238,7 @@ ObservedRun.observe(this)
 | `sampleRate` | Double | Fallback sampling rate (0.0–1.0) applied when no sampling rule matches. Dynamic. |
 | `sampleRules` | List\<Map\> | Ordered rules for per-span sampling. Each rule has a `match` map of tag patterns (plus the reserved `name` key that matches the span's name) and a `sampleRate`. First match wins; unmatched spans use the fallback `sampleRate`. See [Sampling Rules](#sampling-rules) below. Dynamic. |
 | `jdbcTracingEnabled` | Boolean | Emit CLIENT spans for all JDBC `DataSource` operations — applies to every pool (primary + any additional Grails datasources). Defaults to `false`. Dynamic. See [JDBC](#outbound-jdbc) below. |
-| `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. Gated by the `suppressOtlpExport` instance config (defaults to `'true'` in local dev, `'false'` otherwise). |
+| `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. In local development, additionally gated by the `otlpEnabledInLocalDev` instance config (defaults to `'false'`); has no effect in other environments. |
 | `otlpConfig` | Map | OTLP exporter config (e.g. `{"endpoint": "http://localhost:4318/v1/traces"}`). |
 
 When `xhTraceConfig` is updated, the exporter pipeline is torn down and recreated. This is

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -14,7 +14,8 @@ delegate to no-op implementations, so no null checks are needed in application c
 - **Central service** — `TraceService` manages the OpenTelemetry SDK lifecycle, exporter
   pipeline, and provides span creation APIs (`withSpan` and `createSpan`).
 - **Combined observability** — `ObservedRun` is a composable builder that wraps a closure with
-  any combination of tracing, logging, and metrics. Accessed via `BaseService.observe()`.
+  any combination of tracing, logging, and metrics. Typically started via `BaseService.span()`,
+  with `BaseService.observe()` available for the rare case where no span is wanted.
 - **Automatic request spans** — `HoistFilter` creates SERVER spans for every request.
   `HoistFilter` extracts incoming W3C `traceparent` headers so request spans join existing traces.
 - **Export** — OTLP (HTTP/protobuf) export configured via soft config. Applications can register
@@ -68,7 +69,7 @@ root span otherwise. Exceptions are recorded on the span and re-thrown. The clos
 accept a `SpanRef` parameter, which may be further enhanced with tags, or information about errors.
 Note that a NoOp span is passed even if tracing is disabled.
 
-For combined tracing + logging + metrics, use `ObservedRun` via `BaseService.observe()` instead.
+For combined tracing + logging + metrics, use `ObservedRun` via `BaseService.span()` instead.
 
 **Arguments** (passed as named params):
 
@@ -116,8 +117,11 @@ A composable builder for wrapping a closure with any combination of tracing, log
 Each concern is opt-in via dedicated builder methods, then executed with `run()`. The closure is
 wrapped in an onion from outermost to innermost: span → log → timer → counter → closure.
 
-Access via `BaseService.observe()`, which creates a builder pre-configured with the service as
-the caller (used for span `code.namespace` and log context).
+Access via `BaseService.span(name, kind?, tags?)`, which creates a builder pre-configured with
+the service as the caller (used for span `code.namespace` and log context) and an initial span.
+Additional builder methods (`logInfo`, `timer`, `counter`, etc.) can be chained as needed.
+`BaseService.observe()` returns the same builder without an initial span — use it only when no
+span is wanted.
 
 ### Builder methods
 
@@ -138,8 +142,7 @@ When multiple log levels are configured, `ObservedRun` selects the finest enable
 level wins:
 
 ```groovy
-observe()
-    .span(name: 'importData')
+span('importData')
     .logInfo('Importing data')
     .logDebug(['Importing data', [source: url, batchSize: n]])
     .run {
@@ -158,8 +161,7 @@ class PortfolioService extends BaseService {
     Timer generationTimer  // pre-registered Micrometer timer
 
     private Portfolio generatePortfolio() {
-        observe()
-            .span(name: 'generatePortfolio')
+        span('generatePortfolio')
             .logInfo('Generating Portfolio')
             .timer(generationTimer)
             .run {
@@ -172,19 +174,20 @@ class PortfolioService extends BaseService {
 **Span + log only:**
 
 ```groovy
-observe()
-    .span(name: 'generateOrders')
+span('generateOrders')
     .logDebug("Generating ${count} orders")
     .run {
         // business logic
     }
 ```
 
-**Span with SpanRef access:**
+**Span only (with SpanRef access):**
+
+For the common case of a span without logging or metrics, `BaseService.span()` is a shortcut for
+`observe().span(...)`:
 
 ```groovy
-observe()
-    .span(name: 'processOrder', tags: [orderId: id])
+span(name: 'processOrder', tags: [orderId: id])
     .run { SpanRef span ->
         def result = doWork()
         span.setTag('resultCount', result.size())
@@ -196,7 +199,7 @@ observe()
 
 ```groovy
 ObservedRun.observe(this)
-    .span(name: 'myOp')
+    .span('myOp')
     .logDebug('Working')
     .run {
         // works from any LogSupport implementor
@@ -235,7 +238,7 @@ ObservedRun.observe(this)
 | `sampleRate` | Double | Fallback sampling rate (0.0–1.0) applied when no sampling rule matches. Dynamic. |
 | `sampleRules` | List\<Map\> | Ordered rules for per-span sampling. Each rule has a `match` map of tag patterns (plus the reserved `name` key that matches the span's name) and a `sampleRate`. First match wins; unmatched spans use the fallback `sampleRate`. See [Sampling Rules](#sampling-rules) below. Dynamic. |
 | `jdbcTracingEnabled` | Boolean | Emit CLIENT spans for all JDBC `DataSource` operations — applies to every pool (primary + any additional Grails datasources). Defaults to `false`. Dynamic. See [JDBC](#outbound-jdbc) below. |
-| `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. In local development, additionally gated by the `otlpEnabledInLocalDev` instance config (defaults to `'false'`); has no effect in other environments. |
+| `otlpEnabled` | Boolean | Enable OTLP span export (HTTP/protobuf). Dynamic. Gated by the `suppressOtlpExport` instance config (defaults to `'true'` in local dev, `'false'` otherwise). |
 | `otlpConfig` | Map | OTLP exporter config (e.g. `{"endpoint": "http://localhost:4318/v1/traces"}`). |
 
 When `xhTraceConfig` is updated, the exporter pipeline is torn down and recreated. This is

--- a/grails-app/services/io/xh/hoist/http/BaseProxyService.groovy
+++ b/grails-app/services/io/xh/hoist/http/BaseProxyService.groovy
@@ -77,38 +77,36 @@ abstract class BaseProxyService extends BaseService {
         }
         installRequestHeaders(request, method)
 
-        observe()
-            .span(
-                name: request.method,
-                kind: CLIENT,
-                tags: [
-                    'http.request.method': request.method,
-                    'url.full'           : fullPath,
-                    'server.address'     : method.uri.host,
-                    'xh.source'          : 'hoist'
-                ]
-            )
-            .run { SpanRef span ->
-                traceImplService.injectContext(method)
-                try (CloseableHttpResponse sourceResponse = sourceClient.execute(method)) {
-                    response.setStatus(sourceResponse.code)
-                    span.setHttpStatusAndErrorStatus(sourceResponse.code)
-                    installResponseHeaders(response, sourceResponse)
+        span(
+            name: request.method,
+            kind: CLIENT,
+            tags: [
+                'http.request.method': request.method,
+                'url.full'           : fullPath,
+                'server.address'     : method.uri.host,
+                'xh.source'          : 'hoist'
+            ]
+        ).run { SpanRef span ->
+            traceImplService.injectContext(method)
+            try (CloseableHttpResponse sourceResponse = sourceClient.execute(method)) {
+                response.setStatus(sourceResponse.code)
+                span.setHttpStatusAndErrorStatus(sourceResponse.code)
+                installResponseHeaders(response, sourceResponse)
 
-                    sourceResponse.entity?.writeTo(response.outputStream)
+                sourceResponse.entity?.writeTo(response.outputStream)
 
-                    response.flushBuffer()
-                } catch (ClientAbortException ignored) {
-                    logDebug("Client has aborted request to [$endpoint] - ignoring")
-                } catch (Throwable t) {
-                    // Log ...and rethrow exception for normal handling, if not too late
-                    logError("Error occurred during proxy streaming of [$endpoint]", t)
-                    if (!response.isCommitted()) {
-                        response.reset()
-                        throw t
-                    }
+                response.flushBuffer()
+            } catch (ClientAbortException ignored) {
+                logDebug("Client has aborted request to [$endpoint] - ignoring")
+            } catch (Throwable t) {
+                // Log ...and rethrow exception for normal handling, if not too late
+                logError("Error occurred during proxy streaming of [$endpoint]", t)
+                if (!response.isCommitted()) {
+                    response.reset()
+                    throw t
                 }
             }
+        }
     }
 
 

--- a/src/main/groovy/io/xh/hoist/BaseService.groovy
+++ b/src/main/groovy/io/xh/hoist/BaseService.groovy
@@ -17,6 +17,7 @@ import grails.util.GrailsClassUtils
 import groovy.transform.CompileDynamic
 import groovy.transform.NamedParam
 import groovy.transform.NamedVariant
+import io.opentelemetry.api.trace.SpanKind
 import io.xh.hoist.cache.Cache
 import io.xh.hoist.cachedvalue.CachedValue
 import io.xh.hoist.cluster.ClusterService
@@ -297,6 +298,18 @@ abstract class BaseService implements LogSupport, IdentitySupport, DisposableBea
     /** Create an {@link ObservedRun} builder with this service as the caller. */
     ObservedRun observe() {
         ObservedRun.observe(this)
+    }
+
+    /**
+     * Create an {@link ObservedRun} builder with an initial span and this server as a caller.
+     **/
+    @NamedVariant
+    ObservedRun span(
+        @NamedParam(required = true) String name,
+        @NamedParam SpanKind kind = SpanKind.INTERNAL,
+        @NamedParam Map<String, ?> tags = [:]
+    ) {
+        observe().span(name, kind, tags)
     }
 
     //-------------------------------


### PR DESCRIPTION
## Changes

- New `BaseService.span(name, kind?, tags?)` — shortcut for `observe().span(...)`.
- `BaseProxyService` updated to use the new shortcut.
- `docs/tracing.md` examples updated to use `span()`.
- Fixed `docs/tracing.md` `otlpEnabled` row — referenced a non-existent `suppressOtlpExport` config; restored to `otlpEnabledInLocalDev` wording matching `metrics.md` and `OtelUtils`.
- CHANGELOG entry for the new shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)