### PR TITLE
Fix app-side MCP launcher to use bundled content source

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -257,13 +257,17 @@ tasks.register('installHoistCoreTools', Sync) {
         def binDir = file('bin')
         binDir.mkdirs()
         ['mcp', 'docs', 'symbols'].each { topic ->
-            def cliPrefix = topic == 'mcp' ? '' : "cli ${topic}"
+            // mcp mode: pass --source bundled so the server reads JAR-embedded content. Without
+            //           this, HoistCoreMcpServer defaults to local mode and fails when the app
+            //           has no hoist-core checkout sibling.
+            // docs/symbols: dispatched via `cli`, which routes to picocli (defaults to bundled).
+            def args = topic == 'mcp' ? '--source bundled' : "cli ${topic}"
             new File(binDir, "hoist-core-${topic}").with {
-                text = "#!/usr/bin/env bash\nexec java -jar \"${jar.absolutePath}\" ${cliPrefix} \"\$@\"\n"
+                text = "#!/usr/bin/env bash\nexec java -jar \"${jar.absolutePath}\" ${args} \"\$@\"\n"
                 setExecutable(true)
             }
             new File(binDir, "hoist-core-${topic}.bat").text =
-                "@echo off\r\njava -jar \"${jar.absolutePath}\" ${cliPrefix} %*\r\n"
+                "@echo off\r\njava -jar \"${jar.absolutePath}\" ${args} %*\r\n"
         }
     }
 }

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/HoistCoreMcpServer.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/HoistCoreMcpServer.groovy
@@ -6,6 +6,7 @@ import io.modelcontextprotocol.json.McpJsonDefaults
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities
 import io.xh.hoist.mcp.cli.HoistCoreCli
+import io.xh.hoist.mcp.BundledContentSource
 import io.xh.hoist.mcp.data.DocRegistry
 import io.xh.hoist.mcp.data.GroovyRegistry
 import io.xh.hoist.mcp.resources.DocResources
@@ -20,6 +21,14 @@ import io.xh.hoist.mcp.util.McpLog
  * MCP server. Invoking with `cli` as the first argument dispatches the
  * remaining args to {@link HoistCoreCli} for shell-style usage. This dual mode
  * lets a single fat JAR back both the MCP server and the CLI tools.
+ *
+ * Source selection mirrors {@link io.xh.hoist.mcp.cli.CliContext}:
+ *   --source bundled        → JAR-embedded content (use for app-side installs;
+ *                             see App-Side Distribution in mcp/README.md)
+ *   --source local --root P → local checkout (default — used by framework devs
+ *                             running the JAR from inside hoist-core)
+ *   --source github:REF     → downloaded GitHub tarball (existing version-mode
+ *                             bootstrap of the MCP server)
  */
 class HoistCoreMcpServer {
 
@@ -56,7 +65,9 @@ class HoistCoreMcpServer {
 
     private static ContentSource createContentSource(Map config) {
         String source = config.source
-        if (source == 'local') {
+        if (source == 'bundled') {
+            return new BundledContentSource()
+        } else if (source == 'local') {
             String root = config.root ?: resolveRepoRoot()
             return new LocalContentSource(root)
         } else if (source.startsWith('github:')) {


### PR DESCRIPTION
**Fixes the v39 App-Side Distribution path (PR #550)** so the bare MCP server starts when a consuming app has no `../hoist-core/` checkout sibling — the entire premise of that flow.

**Two changes:**
- `HoistCoreMcpServer` now accepts `--source bundled` (was: `local` and `github:<ref>` only).
- `mcp/README.md` install snippet passes `--source bundled` in the mcp launcher.

Bare MCP default is unchanged (`local`) for back-compat with framework devs running the JAR directly from inside a hoist-core checkout (Method 3 in the README).

---

## What was broken

The CLI subtree (`CliContext`) supported `bundled` from day one, so `./bin/hoist-core-{docs,symbols}` always worked. But the bare server's arg parser had no `bundled` branch; the README's install snippet wrote a launcher with no `--source` flags; so `./bin/hoist-core-mcp` inherited the `local` default and crashed with `Cannot determine hoist-core repo root` whenever the consuming app had no sibling checkout.

## Verification

Probe from a JobSite clone in a directory with no sibling hoist-core: `./gradlew installHoistCoreTools` writes the launchers; `./bin/hoist-core-mcp` returns a clean MCP `initialize` JSON-RPC response and loads bundled content (234 files, 29 docs, 201 symbols indexed).

`local`-mode regression check against a real hoist-core checkout: planted a unique sentinel in `docs/base-classes.md`, queried via stdio MCP `tools/call`. Local mode found it at the live filesystem L662 (✓); the same query in bundled mode returned no matches (✓ control — confirms bundled actually reads JAR-frozen content). Sentinel reverted, working tree clean.

## Test plan

- [ ] CI build green
- [ ] `./bin/hoist-core-mcp` starts cleanly from an app checkout with no sibling hoist-core
- [ ] `local` mode still works for framework devs running the JAR directly from a hoist-core checkout