### PR TITLE
Improve MCP/CLI tooling fidelity and ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 40.0-SNAPSHOT
+
+### 🤖 AI Docs + Tooling
+
+* Fidelity and ergonomics improvements to `hoist-core-symbols` / `hoist-core-docs` (CLI + MCP):
+  cleaner Groovydoc rendering, constructors and nested classes indexed, FQN inputs accepted,
+  `get-symbol` falls back to indexed members, `docs read` resolves bare filenames, MCP-aligned
+  CLI verb aliases, and `$JAVA_HOME` launcher fallback.
+
 ## 39.0.1 - 2026-04-30
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   cleaner Groovydoc rendering, constructors and nested classes indexed, FQN inputs accepted,
   `get-symbol` falls back to indexed members, `docs read` resolves bare filenames, MCP-aligned
   CLI verb aliases, and `$JAVA_HOME` launcher fallback.
+* `hoist-core-symbols` now indexes `.java` sources alongside `.groovy` under
+  `src/main/groovy/`, surfacing types previously missing from search and member listings
+  (e.g. `JSONSerializer`, `JSONParser`, `JSONFormat`, `CollectionUtils`, `RoutineException`).
 
 ## 39.0.1 - 2026-04-30
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -135,13 +135,15 @@ with other consumers (e.g. documentation viewers) and aligned with the `docs/REA
 tables. The tradeoff is manual maintenance -- see
 [Maintaining the MCP Server](#maintaining-the-mcp-server).
 
-**Eager Groovy AST initialization.** Parsing hoist-core's Groovy source files with the Groovy
+**Eager Groovy AST initialization.** Parsing hoist-core's source files with the Groovy
 compiler's AST is expensive. After the server starts, `beginInitialization()` kicks off index
 building in a background thread so it runs concurrently while the client sets up. If a tool call
 arrives before init completes, `ensureInitialized()` blocks until the in-flight work finishes. In
 practice, the index is typically ready before the first tool invocation. The index is built using
 Groovy's `CompilationUnit` at the `CONVERSION` phase -- enough for class/method/property extraction
-without full type resolution.
+without full type resolution. Both `.groovy` and `.java` sources under `SOURCE_DIRS` are parsed
+through the same path, so Java types in `src/main/groovy/` (e.g. `JSONSerializer`,
+`CollectionUtils`) are indexed alongside Groovy classes.
 
 **Stdio transport with stderr logging discipline.** Stdout corruption from stray print statements
 is the most common bug in MCP server implementations. A single log statement corrupts the JSON-RPC
@@ -521,8 +523,8 @@ missing, stale, or moved entries and update the registry accordingly.
 Two constants control which source directories are scanned and which classes have their members
 indexed for search:
 
-**`SOURCE_DIRS`** -- lists all source directories to scan for Groovy files. Update when new
-top-level source directories are added to hoist-core.
+**`SOURCE_DIRS`** -- lists all source directories to scan for Groovy and Java files. Update
+when new top-level source directories are added to hoist-core.
 
 **`MEMBER_INDEXED_CLASSES`** -- lists classes whose public members are individually indexed for
 search. Update when a new key base class is added to the framework and should have its members
@@ -533,9 +535,10 @@ searchable, or when an indexed class is renamed or removed.
 **File:** `mcp/build.gradle` (`shadowJar { from(rootProject.projectDir) { include ... } }`)
 
 The fat JAR bundles `docs/`, the `grails-app/{controllers,domain,services,init}` directories,
-and `src/main/groovy/` under the `hoist-core-content/` resource prefix. The `include` patterns
-must match the `SOURCE_DIRS` constant in `data/GroovyRegistry.groovy` -- any new top-level
-source directory must be added to both places.
+and `src/main/groovy/` (both `.groovy` and `.java`) under the `hoist-core-content/` resource
+prefix. The `include` patterns must match the `SOURCE_DIRS` constant in
+`data/GroovyRegistry.groovy` -- any new top-level source directory must be added to both
+places, and any new file extension scanned by the registry must be added to the bundle.
 
 **When to update:**
 - A new top-level source directory is added that the symbol index should scan

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -263,8 +263,30 @@ tasks.register('installHoistCoreTools', Sync) {
             //           has no hoist-core checkout sibling.
             // docs/symbols: dispatched via `cli`, which routes to picocli (defaults to bundled).
             def args = topic == 'mcp' ? '--source bundled' : "cli ${topic}"
+            // The bash launcher resolves `java` from PATH, falling back to JAVA_HOME, so it
+            // works under MCP clients launched from non-interactive shells where a JDK version
+            // manager (mise, asdf, jenv) may not have activated.
             new File(binDir, "hoist-core-${topic}").with {
-                text = "#!/usr/bin/env bash\nexec java -jar \"${jar.absolutePath}\" ${args} \"\$@\"\n"
+                text = """\
+#!/usr/bin/env bash
+if command -v java >/dev/null 2>&1; then
+    JAVA=java
+elif [ -n "\$JAVA_HOME" ] && [ -x "\$JAVA_HOME/bin/java" ]; then
+    JAVA="\$JAVA_HOME/bin/java"
+else
+    cat >&2 <<'EOF'
+[hoist-core] ERROR: 'java' not on PATH and JAVA_HOME is unset or invalid.
+
+If you use a JDK version manager (mise, asdf, jenv), it likely activates only in
+interactive shells - but this script runs in the non-interactive shell launched by
+your MCP client. Either export JAVA_HOME from a non-interactive init file (e.g.
+~/.bash_profile, ~/.zshenv) so it is visible here, or activate the version manager
+from one of those files. Pointing JAVA_HOME at any JDK 17+ install is sufficient.
+EOF
+    exit 1
+fi
+exec "\$JAVA" -jar "${jar.absolutePath}" ${args} "\$@"
+"""
                 setExecutable(true)
             }
             new File(binDir, "hoist-core-${topic}.bat").text =

--- a/mcp/bootstrap.sh
+++ b/mcp/bootstrap.sh
@@ -21,6 +21,26 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Resolve java: prefer PATH, fall back to JAVA_HOME. JDK version managers (mise, asdf, jenv)
+# typically activate only in interactive shells, so a script launched by an MCP client may
+# see neither - in that case, print an actionable error pointing at the likely cause.
+if command -v java >/dev/null 2>&1; then
+    JAVA=java
+elif [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    JAVA="$JAVA_HOME/bin/java"
+else
+    cat >&2 <<'EOF'
+[hoist-core-mcp] ERROR: 'java' not on PATH and JAVA_HOME is unset or invalid.
+
+If you use a JDK version manager (mise, asdf, jenv), it likely activates only in
+interactive shells - but this script runs in the non-interactive shell launched by
+your MCP client. Either export JAVA_HOME from a non-interactive init file (e.g.
+~/.bash_profile, ~/.zshenv) so it is visible here, or activate the version manager
+from one of those files. Pointing JAVA_HOME at any JDK 17+ install is sufficient.
+EOF
+    exit 1
+fi
+
 if [ -n "$VERSION" ]; then
     mkdir -p "$CACHE_DIR/jars"
 
@@ -58,7 +78,7 @@ if [ -n "$VERSION" ]; then
         [ -z "$SOURCE_ARGS" ] && SOURCE_ARGS="--source github:v$VERSION"
     fi
 
-    exec java -jar "$JAR" $SOURCE_ARGS
+    exec "$JAVA" -jar "$JAR" $SOURCE_ARGS
 else
     # Local mode: clean build to ensure JAR reflects current source.
     echo "[hoist-core-mcp] Building MCP server..." >&2
@@ -67,5 +87,5 @@ else
     if [ -z "$JAR" ]; then
         echo "[hoist-core-mcp] ERROR: Could not find or build MCP JAR" >&2; exit 1
     fi
-    exec java -jar "$JAR" $SOURCE_ARGS
+    exec "$JAVA" -jar "$JAR" $SOURCE_ARGS
 fi

--- a/mcp/build.gradle
+++ b/mcp/build.gradle
@@ -45,6 +45,7 @@ shadowJar {
         include 'grails-app/services/**/*.groovy'
         include 'grails-app/init/**/*.groovy'
         include 'src/main/groovy/**/*.groovy'
+        include 'src/main/groovy/**/*.java'
         into 'hoist-core-content'
     }
 

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/cli/DocsCli.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/cli/DocsCli.groovy
@@ -72,11 +72,7 @@ class DocsCli implements Runnable {
                 println JsonOutput.prettyPrint(JsonOutput.toJson(DocFormatter.searchDocsAsMap(query, results)))
                 return 0
             }
-            def text = DocFormatter.formatSearchDocs(query, results)
-            if (results) {
-                text += '\n\nTip: Read any document with `hoist-core-docs read <id>`.'
-            }
-            println text
+            println DocFormatter.formatSearchDocs(query, results)
             return 0
         }
     }
@@ -100,9 +96,7 @@ class DocsCli implements Runnable {
                 ))
                 return 0
             }
-            def text = DocFormatter.formatListDocs(filtered, ctx.docRegistry.mcpCategories)
-            text += '\n\nTip: Read any document with `hoist-core-docs read <id>`.'
-            println text
+            println DocFormatter.formatListDocs(filtered, ctx.docRegistry.mcpCategories)
             return 0
         }
     }
@@ -110,7 +104,7 @@ class DocsCli implements Runnable {
     //------------------------------------------------------------------
     // read
     //------------------------------------------------------------------
-    @Command(name = 'read', description = 'Read a specific document by id.', mixinStandardHelpOptions = true)
+    @Command(name = 'read', aliases = ['get'], description = 'Read a specific document by id.', mixinStandardHelpOptions = true)
     static class Read implements Callable<Integer> {
         @ParentCommand DocsCli parent
         @Parameters(paramLabel = '<docId>', description = 'Document id (e.g. "docs/coding-conventions.md")') String docId
@@ -119,8 +113,22 @@ class DocsCli implements Runnable {
         @Override
         Integer call() {
             def ctx = HoistCoreCli.contextFrom(parent.spec)
-            def entry = ctx.docRegistry.entries.find { it.id == docId }
-            if (!entry) {
+            def res = ctx.docRegistry.resolve(docId)
+            if (res.ambiguous) {
+                if (json) {
+                    println JsonOutput.prettyPrint(JsonOutput.toJson([
+                        schemaVersion: DocFormatter.SCHEMA_VERSION,
+                        id: docId,
+                        found: false,
+                        ambiguous: true,
+                        candidateIds: res.candidates*.id.sort()
+                    ]))
+                    return 1
+                }
+                System.err.println(DocFormatter.formatDocAmbiguous(docId, res.candidates))
+                return 1
+            }
+            if (!res.found) {
                 if (json) {
                     println JsonOutput.prettyPrint(JsonOutput.toJson([
                         schemaVersion: DocFormatter.SCHEMA_VERSION,
@@ -133,9 +141,10 @@ class DocsCli implements Runnable {
                 System.err.println(DocFormatter.formatDocNotFound(docId, ctx.docRegistry.entries))
                 return 1
             }
-            def content = ctx.docRegistry.loadContent(docId)
+            def entry = res.entry
+            def content = ctx.docRegistry.loadContent(entry.id)
             if (content == null) {
-                System.err.println("Document file not readable: \"${docId}\".")
+                System.err.println("Document file not readable: \"${entry.id}\".")
                 return 1
             }
             if (json) {

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/cli/SymbolsCli.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/cli/SymbolsCli.groovy
@@ -74,11 +74,7 @@ class SymbolsCli implements Runnable {
                 ))
                 return 0
             }
-            def text = GroovyFormatter.formatSearchSymbols(query, symbolResults, memberResults)
-            if (symbolResults || memberResults) {
-                text += '\n\nTip: Use `hoist-core-symbols members <Name>` to list all members of a class.'
-            }
-            println text
+            println GroovyFormatter.formatSearchSymbols(query, symbolResults, memberResults)
             return 0
         }
     }
@@ -86,7 +82,7 @@ class SymbolsCli implements Runnable {
     //------------------------------------------------------------------
     // symbol
     //------------------------------------------------------------------
-    @Command(name = 'symbol', description = 'Get detailed type info for a specific symbol.', mixinStandardHelpOptions = true)
+    @Command(name = 'symbol', aliases = ['get'], description = 'Get detailed type info for a specific symbol.', mixinStandardHelpOptions = true)
     static class Symbol implements Callable<Integer> {
         @ParentCommand SymbolsCli parent
         @Parameters(paramLabel = '<name>', description = 'Exact symbol name (e.g. "BaseService")') String name
@@ -96,20 +92,28 @@ class SymbolsCli implements Runnable {
         @Override
         Integer call() {
             def ctx = HoistCoreCli.contextFrom(parent.spec)
-            def detail = ctx.groovyRegistry.getSymbolDetail(name, file)
+            def reg = ctx.groovyRegistry
+            def detail = reg.getSymbolDetail(name, file)
+            // Fallback: if no class/interface match, check the indexed-member surface.
+            // `get-symbol createCache` → method on BaseService instead of "not found".
+            def memberMatches = detail ? [] : reg.findMembersByName(name)
             if (json) {
-                println JsonOutput.prettyPrint(JsonOutput.toJson(GroovyFormatter.getSymbolAsMap(name, detail)))
+                if (detail) {
+                    println JsonOutput.prettyPrint(JsonOutput.toJson(GroovyFormatter.getSymbolAsMap(name, detail)))
+                } else {
+                    println JsonOutput.prettyPrint(JsonOutput.toJson(GroovyFormatter.getMemberAsSymbolAsMap(name, memberMatches)))
+                }
                 return 0
             }
-            if (!detail) {
-                System.err.println(GroovyFormatter.formatSymbolNotFound(name) + ' Use `hoist-core-symbols search` to find available symbols.')
+            if (!detail && !memberMatches) {
+                System.err.println(GroovyFormatter.formatSymbolNotFound(name) + ' Use the `search` subcommand to find available symbols.')
                 return 1
             }
-            def text = GroovyFormatter.formatSymbolDetail(detail)
-            if (detail.kind in ['class', 'interface', 'trait']) {
-                text += "\n\nTip: Use `hoist-core-symbols members ${name}` to see all properties and methods."
+            if (detail) {
+                println GroovyFormatter.formatSymbolDetail(detail)
+            } else {
+                println GroovyFormatter.formatMemberAsSymbol(name, memberMatches)
             }
-            println text
             return 0
         }
     }
@@ -117,7 +121,7 @@ class SymbolsCli implements Runnable {
     //------------------------------------------------------------------
     // members
     //------------------------------------------------------------------
-    @Command(name = 'members', description = 'List all properties and methods of a class or interface.', mixinStandardHelpOptions = true)
+    @Command(name = 'members', aliases = ['list'], description = 'List all properties and methods of a class or interface.', mixinStandardHelpOptions = true)
     static class Members implements Callable<Integer> {
         @ParentCommand SymbolsCli parent
         @Parameters(paramLabel = '<name>', description = 'Class or interface name') String name
@@ -133,7 +137,7 @@ class SymbolsCli implements Runnable {
                 return 0
             }
             if (members == null) {
-                System.err.println(GroovyFormatter.formatMembersNotFound(name) + ' Use `hoist-core-symbols search` to find the correct name.')
+                System.err.println(GroovyFormatter.formatMembersNotFound(name) + ' Use the `search` subcommand to find the correct name.')
                 return 1
             }
             println GroovyFormatter.formatMembers(name, members)

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/data/DocRegistry.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/data/DocRegistry.groovy
@@ -60,6 +60,44 @@ class DocRegistry {
         return contentSource.readFile(entry.id)
     }
 
+    /**
+     * Resolve a doc id with friendly fallbacks for agent-supplied paths:
+     *  1. Exact match.
+     *  2. Auto-prepend `docs/` (handles `tracing.md` → `docs/tracing.md`).
+     *  3. Unambiguous match on the final path segment (handles `tracing.md`
+     *     pointing at `docs/admin-console/tracing.md` if no top-level conflict).
+     * If multiple suffix matches exist, returns a resolution with `candidates`
+     * populated so the caller can ask the user to disambiguate.
+     */
+    DocResolution resolve(String requested) {
+        if (!requested) return new DocResolution()
+
+        // 1. Exact match
+        def exact = entries.find { it.id == requested }
+        if (exact) return new DocResolution(entry: exact)
+
+        // 2. Prepend `docs/` if not already prefixed
+        if (!requested.startsWith('docs/')) {
+            def prefixed = entries.find { it.id == "docs/${requested}" }
+            if (prefixed) return new DocResolution(entry: prefixed)
+        }
+
+        // 3. Suffix match on final path segment
+        def lastSeg = requested.tokenize('/').last()
+        def suffixMatches = entries.findAll { it.id.tokenize('/').last() == lastSeg }
+        if (suffixMatches.size() == 1) return new DocResolution(entry: suffixMatches[0])
+        if (suffixMatches.size() > 1) return new DocResolution(candidates: suffixMatches)
+
+        return new DocResolution()
+    }
+
+    static class DocResolution {
+        DocEntry entry
+        List<DocEntry> candidates = []
+        boolean isFound() { entry != null }
+        boolean isAmbiguous() { entry == null && !candidates.empty }
+    }
+
     //------------------------------------------------------------------
     // JSON loading
     //------------------------------------------------------------------

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/data/GroovyRegistry.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/data/GroovyRegistry.groovy
@@ -17,6 +17,10 @@ import java.util.concurrent.CountDownLatch
 /**
  * AST-based symbol extraction from hoist-core Groovy/Java source files.
  * Provides indexed search over classes, methods, and properties.
+ *
+ * Both .groovy and .java sources are parsed via Groovy's CompilationUnit at
+ * CompilePhase.CONVERSION — this surfaces ClassNodes, methods, fields, and
+ * Javadoc/Groovydoc uniformly without a separate Java parser dependency.
  */
 class GroovyRegistry {
 
@@ -194,7 +198,8 @@ class GroovyRegistry {
         int fileCount = 0, symbolCount = 0, memberCount = 0
 
         for (sourceDir in SOURCE_DIRS) {
-            def files = contentSource.findFiles(sourceDir.dir, '.groovy')
+            def files = contentSource.findFiles(sourceDir.dir, '.groovy') +
+                contentSource.findFiles(sourceDir.dir, '.java')
             for (relPath in files) {
                 try {
                     def classes = parseFileClasses(relPath)
@@ -355,6 +360,9 @@ class GroovyRegistry {
             if (isPrivate(method.name)) continue
             if (method.isSynthetic()) continue
             if (method.name.startsWith('$')) continue
+            // Skip JVM-synthesized initializer methods (<clinit>, <init>) that surface
+            // when parsing Java sources via Groovy's CompilationUnit.
+            if (method.name.startsWith('<')) continue
             // Skip property getters/setters
             if (isPropertyAccessor(method, propertyNames)) continue
 

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/data/GroovyRegistry.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/data/GroovyRegistry.groovy
@@ -3,6 +3,7 @@ package io.xh.hoist.mcp.data
 import io.xh.hoist.mcp.ContentSource
 import io.xh.hoist.mcp.util.McpLog
 import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.ConstructorNode
 import org.codehaus.groovy.ast.FieldNode
 import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.Parameter
@@ -78,7 +79,8 @@ class GroovyRegistry {
     //------------------------------------------------------------------
     List<SymbolEntry> searchSymbols(String query, String kind = null, int limit = 20) {
         ensureInitialized()
-        def queryLower = query.toLowerCase()
+        def normalizedQuery = simpleSymbolName(query)
+        def queryLower = normalizedQuery.toLowerCase()
 
         def results = symbolIndex.values().flatten().findAll { SymbolEntry entry ->
             if (kind && entry.kind != kind) return false
@@ -87,8 +89,8 @@ class GroovyRegistry {
 
         // Sort: exact matches first, then by name
         results.sort { a, b ->
-            def aExact = a.name.equalsIgnoreCase(query) ? 0 : 1
-            def bExact = b.name.equalsIgnoreCase(query) ? 0 : 1
+            def aExact = a.name.equalsIgnoreCase(normalizedQuery) ? 0 : 1
+            def bExact = b.name.equalsIgnoreCase(normalizedQuery) ? 0 : 1
             if (aExact != bExact) return aExact <=> bExact
             return a.name <=> b.name
         }
@@ -98,15 +100,16 @@ class GroovyRegistry {
 
     List<MemberIndexEntry> searchMembers(String query, int limit = 15) {
         ensureInitialized()
-        def queryLower = query.toLowerCase()
+        def normalizedQuery = simpleSymbolName(query)
+        def queryLower = normalizedQuery.toLowerCase()
 
         def results = memberIndex.values().flatten().findAll { MemberIndexEntry entry ->
             entry.name.toLowerCase().contains(queryLower)
         }
 
         results.sort { a, b ->
-            def aExact = a.name.equalsIgnoreCase(query) ? 0 : 1
-            def bExact = b.name.equalsIgnoreCase(query) ? 0 : 1
+            def aExact = a.name.equalsIgnoreCase(normalizedQuery) ? 0 : 1
+            def bExact = b.name.equalsIgnoreCase(normalizedQuery) ? 0 : 1
             if (aExact != bExact) return aExact <=> bExact
             if (a.name != b.name) return a.name <=> b.name
             return a.ownerName <=> b.ownerName
@@ -120,7 +123,8 @@ class GroovyRegistry {
     //------------------------------------------------------------------
     SymbolDetail getSymbolDetail(String name, String filePath = null) {
         ensureInitialized()
-        def entries = symbolIndex[name.toLowerCase()] ?: []
+        def lookup = simpleSymbolName(name)
+        def entries = symbolIndex[lookup.toLowerCase()] ?: []
         if (entries.empty) return null
 
         def entry = filePath
@@ -128,7 +132,7 @@ class GroovyRegistry {
             : entries[0]
         if (!entry) return null
 
-        def classNode = parseFile(entry.filePath)
+        def classNode = findClassInFile(entry.filePath, entry.name)
         if (!classNode) return null
 
         return buildSymbolDetail(classNode, entry)
@@ -136,7 +140,8 @@ class GroovyRegistry {
 
     List<MemberInfo> getMembers(String name, String filePath = null) {
         ensureInitialized()
-        def entries = symbolIndex[name.toLowerCase()] ?: []
+        def lookup = simpleSymbolName(name)
+        def entries = symbolIndex[lookup.toLowerCase()] ?: []
         if (entries.empty) return null
 
         def entry = filePath
@@ -144,10 +149,41 @@ class GroovyRegistry {
             : entries[0]
         if (!entry) return null
 
-        def classNode = parseFile(entry.filePath)
+        def classNode = findClassInFile(entry.filePath, entry.name)
         if (!classNode) return null
 
         return extractMembers(classNode)
+    }
+
+    private ClassNode findClassInFile(String relPath, String simpleName) {
+        return parseFileClasses(relPath).find { extractSimpleName(it).equalsIgnoreCase(simpleName) }
+    }
+
+    /**
+     * Look up indexed members by exact name (case-insensitive) — used as a fallback when
+     * `get-symbol <name>` doesn't match a class. An agent searching for e.g. `createCache`
+     * gets a useful pointer instead of "not found", since that name is a method on
+     * `BaseService`.
+     */
+    List<MemberIndexEntry> findMembersByName(String name) {
+        ensureInitialized()
+        def lookup = simpleSymbolName(name)
+        def hits = memberIndex[lookup.toLowerCase()] ?: []
+        return hits.findAll { it.name.equalsIgnoreCase(lookup) }
+    }
+
+    /**
+     * Strip package and outer-class prefixes from a symbol name so that agents can paste
+     * fully-qualified or nested references and still get a hit. Examples:
+     *   io.xh.hoist.util.Timer            -> Timer
+     *   io.xh.hoist.ldap.LdapConfig$Inner -> Inner
+     *   BaseService.createTimer           -> createTimer
+     *   Timer                             -> Timer
+     */
+    static String simpleSymbolName(String input) {
+        if (!input) return input
+        def afterDot = input.contains('.') ? input.substring(input.lastIndexOf('.') + 1) : input
+        return afterDot.contains('$') ? afterDot.substring(afterDot.lastIndexOf('$') + 1) : afterDot
     }
 
     //------------------------------------------------------------------
@@ -161,41 +197,47 @@ class GroovyRegistry {
             def files = contentSource.findFiles(sourceDir.dir, '.groovy')
             for (relPath in files) {
                 try {
-                    def classNode = parseFile(relPath)
-                    if (!classNode) continue
+                    def classes = parseFileClasses(relPath)
+                    if (classes.empty) continue
 
                     fileCount++
-                    def entry = new SymbolEntry(
-                        name: classNode.nameWithoutPackage,
-                        kind: classKind(classNode),
-                        filePath: relPath,
-                        sourceCategory: sourceDir.category,
-                        packageName: classNode.packageName ?: '',
-                        isAbstract: classNode.isAbstract()
-                    )
+                    for (ClassNode classNode in classes) {
+                        def simpleName = extractSimpleName(classNode)
+                        def entry = new SymbolEntry(
+                            name: simpleName,
+                            kind: classKind(classNode),
+                            filePath: relPath,
+                            sourceCategory: sourceDir.category,
+                            packageName: classNode.packageName ?: '',
+                            isAbstract: classNode.isAbstract()
+                        )
 
-                    def key = entry.name.toLowerCase()
-                    symbolIndex.computeIfAbsent(key) { [] } << entry
-                    symbolCount++
+                        symbolIndex.computeIfAbsent(simpleName.toLowerCase()) { [] } << entry
+                        symbolCount++
 
-                    // Index members of curated classes
-                    if (entry.name in MEMBER_INDEXED_CLASSES) {
-                        def members = extractMembers(classNode)
-                        for (member in members) {
-                            def memberKey = member.name.toLowerCase()
-                            memberIndex.computeIfAbsent(memberKey) { [] } << new MemberIndexEntry(
-                                name: member.name,
-                                memberKind: member.kind,
-                                ownerName: entry.name,
-                                filePath: relPath,
-                                sourceCategory: sourceDir.category,
-                                isStatic: member.isStatic,
-                                type: member.type,
-                                groovydoc: member.groovydoc,
-                                annotations: member.annotations
-                            )
+                        // Index members of curated classes
+                        if (simpleName in MEMBER_INDEXED_CLASSES) {
+                            def members = extractMembers(classNode)
+                            for (member in members) {
+                                // Skip constructors: their name == class name, so a search hit
+                                // would duplicate the class symbol result.
+                                if (member.kind == 'constructor') continue
+                                def memberKey = member.name.toLowerCase()
+                                memberIndex.computeIfAbsent(memberKey) { [] } << new MemberIndexEntry(
+                                    name: member.name,
+                                    memberKind: member.kind,
+                                    ownerName: simpleName,
+                                    filePath: relPath,
+                                    sourceCategory: sourceDir.category,
+                                    isStatic: member.isStatic,
+                                    type: member.type,
+                                    groovydoc: member.groovydoc,
+                                    annotations: member.annotations,
+                                    parameters: member.parameters
+                                )
+                            }
+                            memberCount += members.size()
                         }
-                        memberCount += members.size()
                     }
                 } catch (Exception e) {
                     McpLog.warn("Failed to parse ${relPath}: ${e.message}")
@@ -209,9 +251,15 @@ class GroovyRegistry {
     //------------------------------------------------------------------
     // AST parsing
     //------------------------------------------------------------------
-    private ClassNode parseFile(String relPath) {
+    /**
+     * Parse a Groovy file and return ALL non-script classes — top-level + nested.
+     * Inner classes appear in `unit.AST.classes` alongside their outer class with
+     * `name` like `Outer$Inner`; we keep them so they can be indexed and looked up
+     * under their bare simple names.
+     */
+    private List<ClassNode> parseFileClasses(String relPath) {
         def content = contentSource.readFile(relPath)
-        if (!content) return null
+        if (!content) return []
 
         try {
             def config = new CompilerConfiguration()
@@ -221,16 +269,15 @@ class GroovyRegistry {
             unit.addSource(relPath, content)
             unit.compile(CompilePhase.CONVERSION.phaseNumber)
 
-            // Get the first class from the compilation
-            def classes = unit.AST?.classes
-            if (!classes) return null
-
-            // Return the primary class (skip script class)
-            return classes.find { !it.isScript() } ?: classes[0]
+            return (unit.AST?.classes ?: []).findAll { !it.isScript() }
         } catch (Exception e) {
-            // CONVERSION phase should rarely fail, but guard against syntax errors
-            return null
+            return []
         }
+    }
+
+    /** Bare class name without package or `Outer$` prefix (e.g. `LdapServerOptions`). */
+    private static String extractSimpleName(ClassNode c) {
+        return (c.nameWithoutPackage ?: c.name ?: '').tokenize('$').last()
     }
 
     private static String classKind(ClassNode node) {
@@ -279,6 +326,27 @@ class GroovyRegistry {
                 isAbstract: false,
                 groovydoc: extractGroovydoc(field),
                 annotations: annotationNames(field.annotations)
+            )
+        }
+
+        // Constructors — surfaced as a distinct member kind so DTO-style classes
+        // (POGOs, exception types, TypedConfigMap subclasses) advertise their entry points.
+        for (ConstructorNode ctor in classNode.declaredConstructors) {
+            if (ctor.isSynthetic()) continue
+            if (java.lang.reflect.Modifier.isPrivate(ctor.modifiers)) continue
+            def ctorName = extractSimpleName(classNode)
+            members << new MemberInfo(
+                name: ctorName,
+                kind: 'constructor',
+                type: ctorName,
+                visibility: visibilityStr(ctor.modifiers),
+                isStatic: false,
+                isAbstract: false,
+                groovydoc: extractGroovydoc(ctor),
+                annotations: annotationNames(ctor.annotations),
+                parameters: ctor.parameters.collect { Parameter p ->
+                    new ParameterInfo(name: p.name, type: typeName(p.type))
+                }
             )
         }
 
@@ -362,15 +430,54 @@ class GroovyRegistry {
 
     private static String cleanDocComment(String raw) {
         if (!raw) return ''
-        return raw
-            .replaceAll(/(?m)^\s*\/?\*+\/?/, '')  // Remove /** */ * markers
-            .replaceAll(/@\w+.*/, '')                // Remove @param etc tags
-            .trim()
+        String s = raw
+
+        // 1. Strip Groovydoc comment framing.
+        s = s.replaceAll(/(?m)^\s*\/\*+/, '')         // /** at line start
+        s = s.replaceAll(/(?m)\*+\/\s*$/, '')         // */ at line end (line-only or inline-trailing)
+        s = s.replaceAll(/(?m)^\s*\*+\s?/, '')        // line-leading * continuation markers
+
+        // 2. Render <pre>{@code ...}</pre> and bare <pre>...</pre> blocks as fenced code blocks.
+        // Non-greedy with the `}\s*</pre>` anchor handles examples that contain inner braces.
+        s = s.replaceAll(/(?s)<pre>\s*\{@code\s*(.*?)\s*\}\s*<\/pre>/, '\n```groovy\n$1\n```\n')
+        s = s.replaceAll(/(?s)<pre>\s*(.*?)\s*<\/pre>/, '\n```\n$1\n```\n')
+
+        // 3. Render inline Groovydoc tags. {@link X}, {@link X#y}, {@link X label} → backtick.
+        s = s.replaceAll(/\{@code\s+([^}]+)\}/, '`$1`')
+        s = s.replaceAll(/\{@literal\s+([^}]+)\}/, '$1')
+        s = renderLinkTags(s)
+
+        // 4. Strip block tags (@param, @return, @throws, @since, ...) — line-anchored only,
+        //    so mid-prose `{@link}` references aren't eaten.
+        s = s.replaceAll(/(?m)^\s*@\w+\b.*$/, '')
+
+        // 5. Strip remaining stray HTML tags that don't carry semantic value.
+        s = s.replaceAll(/<\/?(p|em|i|b|strong|br|ul|ol|li|h\d)\s*\/?>/, '')
+
+        // 6. Right-trim each line, collapse 3+ blank-line runs to 2, and outer-trim.
+        return s
             .split('\n')
-            .collect { it.trim() }
-            .findAll { it }
-            .take(3)                                 // First 3 meaningful lines
-            .join(' ')
+            .collect { it.replaceAll(/\s+$/, '') }
+            .join('\n')
+            .replaceAll(/\n{3,}/, '\n\n')
+            .trim()
+    }
+
+    private static String renderLinkTags(String s) {
+        return s.replaceAll(/\{@link\s+([^}]+)\}/) { match, content ->
+            def trimmed = content.trim()
+            def spaceIdx = trimmed.indexOf(' ')
+            if (spaceIdx >= 0) {
+                // Explicit label: {@link Foo bar baz} → `bar baz`
+                return "`${trimmed.substring(spaceIdx + 1).trim()}`"
+            }
+            // Strip package qualifier: io.xh.foo.Bar#baz → Bar#baz
+            def simple = trimmed.contains('.') ? trimmed.substring(trimmed.lastIndexOf('.') + 1) : trimmed
+            // Member-ref form: Class#member → Class.member; bare #member → member
+            simple = simple.replace('#', '.')
+            if (simple.startsWith('.')) simple = simple.substring(1)
+            return "`${simple}`"
+        }
     }
 
     //------------------------------------------------------------------
@@ -439,6 +546,7 @@ class GroovyRegistry {
         String name, memberKind, ownerName, filePath, sourceCategory, type, groovydoc
         boolean isStatic
         List<String> annotations = []
+        List<ParameterInfo> parameters = []
     }
 
     static class ParameterInfo {

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/formatters/DocFormatter.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/formatters/DocFormatter.groovy
@@ -117,4 +117,10 @@ class DocFormatter {
         def ids = available*.id.sort().join(', ')
         return "Unknown document id: \"${docId}\". Available ids: ${ids}"
     }
+
+    /** Error text when a doc id matches multiple entries by suffix; lists candidates. */
+    static String formatDocAmbiguous(String docId, List<DocEntry> candidates) {
+        def ids = candidates*.id.sort().join(', ')
+        return "Ambiguous document id: \"${docId}\" matches multiple entries. Specify one of: ${ids}"
+    }
 }

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/formatters/GroovyFormatter.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/formatters/GroovyFormatter.groovy
@@ -45,7 +45,7 @@ class GroovyFormatter {
                 def staticPrefix = m.isStatic ? 'static ' : ''
                 def typeStr = truncateType(m.type)
                 lines << "${i + 1}. [${m.memberKind}] ${staticPrefix}${m.name}: ${typeStr} (on ${m.ownerName})"
-                if (m.groovydoc) lines << "    ${m.groovydoc}"
+                if (m.groovydoc) lines << "    ${docPreview(m.groovydoc)}"
             }
         }
         return lines.join('\n').stripTrailing()
@@ -111,6 +111,77 @@ class GroovyFormatter {
         return lines.join('\n').stripTrailing()
     }
 
+    /**
+     * Member-as-symbol fallback view, used when `get-symbol <name>` matches an indexed
+     * member rather than a class (e.g. `createCache` → method on `BaseService`).
+     * Renders enough signature + Groovydoc to be useful, and points at the owning class
+     * so the agent can pivot to `get-members` if they want full context.
+     */
+    static String formatMemberAsSymbol(String name, List<MemberIndexEntry> matches) {
+        if (!matches) return formatSymbolNotFound(name)
+
+        def displayName = io.xh.hoist.mcp.data.GroovyRegistry.simpleSymbolName(name)
+        def lines = []
+        if (matches.size() == 1) {
+            lines << "# ${displayName} (${matches[0].memberKind}, member of ${matches[0].ownerName})"
+        } else {
+            lines << "# ${displayName} — ${matches.size()} member matches"
+        }
+        lines << ''
+        matches.eachWithIndex { m, i ->
+            if (matches.size() > 1) {
+                lines << "## ${i + 1}. on ${m.ownerName}"
+            }
+            lines << "Owner: ${m.ownerName}"
+            lines << "File: ${m.filePath}"
+            lines << "Kind: ${m.memberKind}${m.isStatic ? ' (static)' : ''}"
+            lines << ''
+            lines << '## Signature'
+            lines << memberSignature(m)
+            if (m.groovydoc) {
+                lines << ''
+                lines << '## Documentation'
+                lines << m.groovydoc
+            }
+            if (i < matches.size() - 1) lines << ''
+        }
+        return lines.join('\n').stripTrailing()
+    }
+
+    static Map getMemberAsSymbolAsMap(String name, List<MemberIndexEntry> matches) {
+        return [
+            schemaVersion: SCHEMA_VERSION,
+            name: name,
+            found: !matches.empty,
+            resolution: 'member',
+            matches: matches.collect { m ->
+                [
+                    name: m.name,
+                    memberKind: m.memberKind,
+                    ownerName: m.ownerName,
+                    filePath: m.filePath,
+                    sourceCategory: m.sourceCategory,
+                    type: m.type,
+                    isStatic: m.isStatic,
+                    annotations: m.annotations ?: [],
+                    parameters: m.parameters?.collect { [name: it.name, type: it.type] } ?: [],
+                    groovydoc: m.groovydoc ?: ''
+                ]
+            }
+        ]
+    }
+
+    private static String memberSignature(MemberIndexEntry m) {
+        def staticPrefix = m.isStatic ? 'static ' : ''
+        def annotationPrefix = m.annotations ? m.annotations.collect { "@${it}" }.join(' ') + ' ' : ''
+        if (m.memberKind == 'method') {
+            def params = m.parameters?.collect { "${it.name}: ${truncateType(it.type)}" }?.join(', ') ?: ''
+            def ret = truncateType(m.type ?: 'void')
+            return "${staticPrefix}${annotationPrefix}${m.name}(${params}): ${ret}"
+        }
+        return "${staticPrefix}${annotationPrefix}${m.name}: ${truncateType(m.type)}"
+    }
+
     static Map getSymbolAsMap(String name, SymbolDetail detail) {
         if (!detail) {
             return [schemaVersion: SCHEMA_VERSION, name: name, found: false, symbol: null]
@@ -143,13 +214,20 @@ class GroovyFormatter {
     }
 
     static String formatMembers(String name, List<MemberInfo> members) {
+        def constructors = members.findAll { it.kind == 'constructor' }
         def instanceProps = members.findAll { !it.isStatic && it.kind in ['property', 'field'] }
         def instanceMethods = members.findAll { !it.isStatic && it.kind == 'method' }
         def staticProps = members.findAll { it.isStatic && it.kind in ['property', 'field'] }
         def staticMethods = members.findAll { it.isStatic && it.kind == 'method' }
 
-        def lines = ["# ${name} Members", '']
+        def displayName = io.xh.hoist.mcp.data.GroovyRegistry.simpleSymbolName(name)
+        def lines = ["# ${displayName} Members", '']
 
+        if (constructors) {
+            lines << "## Constructors (${constructors.size()})"
+            constructors.each { lines << formatMemberLine(it) }
+            lines << ''
+        }
         if (instanceProps) {
             lines << "## Properties (${instanceProps.size()})"
             instanceProps.each { lines << formatMemberLine(it) }
@@ -210,13 +288,26 @@ class GroovyFormatter {
             def params = member.parameters?.collect { "${it.name}: ${truncateType(it.type)}" }?.join(', ') ?: ''
             def ret = truncateType(member.type ?: 'void')
             lines << "- ${annotationPrefix}${member.name}(${params}): ${ret}"
+        } else if (member.kind == 'constructor') {
+            def params = member.parameters?.collect { "${it.name}: ${truncateType(it.type)}" }?.join(', ') ?: ''
+            lines << "- ${annotationPrefix}${member.name}(${params})"
         } else {
             lines << "- ${annotationPrefix}${member.name}: ${truncateType(member.type)}"
         }
         if (member.groovydoc) {
-            lines << "    ${member.groovydoc.split('\n')[0]}"
+            lines << "    ${docPreview(member.groovydoc)}"
         }
         return lines.join('\n')
+    }
+
+    /**
+     * One-line preview: first paragraph of the Groovydoc with soft line-wraps collapsed.
+     * Source Groovydocs often wrap prose at ~80 chars; taking just the first physical
+     * line would cut mid-clause.
+     */
+    private static String docPreview(String groovydoc) {
+        def firstPara = groovydoc.split(/\n\s*\n/, 2)[0]
+        return firstPara.split('\n').collect { it.trim() }.findAll { it }.join(' ')
     }
 
     private static String truncateType(String typeStr) {

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/tools/DocTools.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/tools/DocTools.groovy
@@ -70,11 +70,7 @@ class DocTools {
             int limit = (args?.limit as Integer) ?: 10
 
             def results = registry.searchDocs(query, category, limit)
-            def text = DocFormatter.formatSearchDocs(query, results)
-            if (results) {
-                text += '\n\nTip: Use hoist-core-read-doc with an id to read the full document.'
-            }
-            return textResult(text)
+            return textResult(DocFormatter.formatSearchDocs(query, results))
         })
     }
 
@@ -138,15 +134,18 @@ class DocTools {
             def args = request?.arguments() ?: [:]
             String id = args?.id ?: ''
 
-            def entry = registry.entries.find { it.id == id }
-            if (!entry) {
+            def res = registry.resolve(id)
+            if (res.ambiguous) {
+                return textResult(DocFormatter.formatDocAmbiguous(id, res.candidates))
+            }
+            if (!res.found) {
                 return textResult(DocFormatter.formatDocNotFound(id, registry.entries))
             }
-            def content = registry.loadContent(id)
+            def content = registry.loadContent(res.entry.id)
             if (content == null) {
-                return textResult("Document file not readable: \"${id}\".")
+                return textResult("Document file not readable: \"${res.entry.id}\".")
             }
-            return textResult(DocFormatter.formatReadDoc(entry, content))
+            return textResult(DocFormatter.formatReadDoc(res.entry, content))
         })
     }
 

--- a/mcp/src/main/groovy/io/xh/hoist/mcp/tools/GroovyTools.groovy
+++ b/mcp/src/main/groovy/io/xh/hoist/mcp/tools/GroovyTools.groovy
@@ -69,11 +69,7 @@ class GroovyTools {
             int memberLimit = symbolResults.empty ? symbolLimit : 15
             def memberResults = registry.searchMembers(query, memberLimit)
 
-            def text = GroovyFormatter.formatSearchSymbols(query, symbolResults, memberResults)
-            if (symbolResults || memberResults) {
-                text += '\n\nTip: Use hoist-core-get-members to see all members of a specific class.'
-            }
-            return textResult(text)
+            return textResult(GroovyFormatter.formatSearchSymbols(query, symbolResults, memberResults))
         })
     }
 
@@ -108,14 +104,16 @@ class GroovyTools {
             String filePath = args?.filePath
 
             def detail = registry.getSymbolDetail(name, filePath)
-            if (!detail) {
-                return textResult(GroovyFormatter.formatSymbolNotFound(name) + ' Use hoist-core-search-symbols to find available symbols.')
+            if (detail) {
+                return textResult(GroovyFormatter.formatSymbolDetail(detail))
             }
-            def text = GroovyFormatter.formatSymbolDetail(detail)
-            if (detail.kind in ['class', 'interface', 'trait']) {
-                text += '\n\nUse hoist-core-get-members to see all properties and methods.'
+            // Fallback: try the indexed-member surface so `get-symbol createCache` resolves to
+            // the method on BaseService rather than dead-ending at "not found".
+            def memberMatches = registry.findMembersByName(name)
+            if (memberMatches) {
+                return textResult(GroovyFormatter.formatMemberAsSymbol(name, memberMatches))
             }
-            return textResult(text)
+            return textResult(GroovyFormatter.formatSymbolNotFound(name) + ' Use hoist-core-search-symbols to find available symbols.')
         })
     }
 


### PR DESCRIPTION
## TL;DR

**What changed (all in `mcp/`):**
- Symbol tools render Groovydoc cleanly — no more `{@link}` / `<pre>` / `*/` artifacts, no mid-clause cuts
- Constructors and nested/inner classes now indexed and visible
- `.java` sources under `src/main/groovy/` now indexed alongside `.groovy` — closes a coverage gap that hid types like `JSONSerializer`, `JSONParser`, `JSONFormat`, `CollectionUtils`, and `RoutineException` from search and member listings entirely
- `get-symbol` accepts FQN inputs and falls back to indexed members when the name is a method (e.g. `createCache` resolves to `BaseService.createCache` instead of "not found")
- `docs read` resolves bare filenames (`tracing.md` → `docs/tracing.md`)
- CLI subcommands gain MCP-aligned aliases (`symbols get`, `symbols list`, `docs get`); tip-suffix noise removed
- Launchers fall back to `$JAVA_HOME/bin/java` when `java` isn't on `PATH`, with an actionable error mentioning `mise` / `asdf` / `jenv` activation when neither resolves

**What didn't change:**
- No Hoist Core public API — zero non-`mcp/` runtime files touched
- App-side install snippet unchanged — apps rerun `./gradlew installHoistCoreTools` to pick up the launcher's `$JAVA_HOME` fallback
- Doc *content* untouched — Groovydoc thinness on some classes is a separate, parallel improvement effort

---

## Detail

### Symbol-output rendering (`GroovyRegistry.cleanDocComment`)

The previous implementation capped at 3 source lines and stripped `@`-prefixed tags with an over-broad regex, which together produced the artifacts that prompted this PR — most visibly `"Subclasses declare their properties and must call { <pre>"` on `TypedConfigMap` and `"Similar to { Like Cache,"` on `CachedValue`. Rewritten to anchor block-tag stripping to line start (so mid-prose `{@link}` / `{@code}` references survive), render inline tags as backtick-quoted refs, render `<pre>{@code ... }</pre>` as fenced markdown code blocks, strip mid-line `*/` Groovydoc closers, and drop the line cap entirely. Per-member previews use a new `docPreview` helper that collapses soft line wraps in the first paragraph so summaries no longer cut mid-clause when the source Groovydoc wraps prose at ~80 chars.

### Constructor + nested-class indexing

`extractMembers` now pulls `declaredConstructors` and surfaces them in a `## Constructors` section above `## Properties`. Constructor-only classes like `RoutineRuntimeException` used to render as "No members found"; they now show `RoutineRuntimeException(s: String)`. `parseFile` (returned a single ClassNode) became `parseFileClasses` (returns all top-level + inner classes), so nested classes like `LdapServerOptions` (in `LdapConfig`) are now findable by bare name.

### Java source indexing

The registry previously scanned only `.groovy` files, so Java types under `src/main/groovy/` returned "not found" — including high-traffic ones (`JSONSerializer`, `JSONParser`, `JSONFormat`) that CLAUDE.md explicitly directs agents at as the authoritative reference, plus `CollectionUtils`, `RoutineException`, the Kryo serializers, and the JSON serializer modules. Groovy 4's `CompilationUnit` handles `.java` cleanly at `CompilePhase.CONVERSION` (methods, fields, params, return types, Javadoc all surface as `ClassNode`s), so both extensions now flow through the same parsing path with no new dependency. Adds a `<clinit>`/`<init>` filter for JVM-synthesized initializer methods that surface from Java sources, extends the shadowJar bundle to include `.java`, and updates `mcp/README` maintenance guidance to cover the new extension.

### `get-symbol` member fallback

Previously `get-symbol createCache` returned "Symbol not found" even though `search-symbols` happily surfaced it as a member of `BaseService`. The fallback now checks the indexed-member surface and returns a focused signature, Groovydoc, and owner pointer in the same format as a class lookup, so agents avoid a forced extra tool call.

### FQN normalization

Agents naturally paste the qualified form they see in search output (`io.xh.hoist.util.Timer`). Previously this produced "not found" on `symbol` / `members`. The registry now strips package and `Outer$` prefixes before lookup, so `io.xh.hoist.util.Timer`, `LdapConfig$LdapServerOptions`, and `BaseService.createTimer` (which falls into the member-fallback path) all resolve.

### Doc-id resolution

`DocRegistry.resolve(id)` adds three-step fallback: exact match → auto-prepend `docs/` → unambiguous suffix match. Bare `tracing.md` resolves to `docs/tracing.md`; `v39-upgrade-notes.md` resolves to `docs/upgrade-notes/v39-upgrade-notes.md`. Multi-match cases return a "did you mean" error listing the candidates.

### CLI verb aliases + error redirect text

Picocli `aliases` on `symbols symbol` (→ `get`), `symbols members` (→ `list`), `docs read` (→ `get`) — agents who reach for the MCP-style verb name no longer fail. The CLI not-found redirects no longer reference the launcher binary by name (which is wrong from a `java -jar … cli …` invocation); they now just say "Use the `search` subcommand to find available symbols."

### Launcher robustness

`mcp/bootstrap.sh` and the Gradle install snippet's bash launcher now resolve `java` from `PATH`, falling back to `$JAVA_HOME/bin/java`. Both emit an actionable error naming `mise` / `asdf` / `jenv` as the likely cause when neither resolves — addresses a real failure mode where a JDK version manager activates only in interactive shells, but the MCP client launches a non-interactive shell.

## Validation

Re-ran the same four onboarding-flavored research tasks against the rebuilt JAR (typed JSON soft config, cluster-wide scheduled timer, `Cache` vs `CachedValue`, custom monitor) with independent agents. Across the four: zero reports of `{@link}` / `<pre>` / `*/` rendering issues (was 100% hit rate across 4 agents and 7 distinct symbols in round 1), zero CLI/MCP verb confusion (was 3 of 4 in round 1), zero "no members found" surprises (was 1 of 4 in round 1), zero source-file fallbacks needed (was 1 of 4 in round 1). Round 2 also surfaced the FQN-rejection and launcher-name-in-error-message issues, both fixed in this PR. The Java-indexing gap was caught after that round when an agent's `members CollectionUtils` query returned "not found" despite the file existing on disk.

## Out of scope (flagged for follow-up)

- Hoist Gradle plugin — discussed; deferred. Direction is a same-repo plugin module sibling to `mcp/` that absorbs the install-snippet duplication across consuming apps.
- Search ranking by raw match count — `base-classes.md` (67 matches) outranks `clustering.md` (44) for "Cache vs CachedValue" even though clustering is the on-point doc; a multi-term proximity weight would help.
- `docs read --section` flag for navigating long docs (`monitoring.md`, `configuration.md`, `base-classes.md`).
- `@MapConstructor` / `@TupleConstructor` POGOs show no constructors (the annotation-generated ones aren't in `declaredConstructors`); detection + synthesis would close the gap.
- Doc-content improvements (Groovydoc thinness on key classes, HTML entity rendering, search-snippet artifacts) — parallel effort.

## Test plan

- [x] Compiles clean (`./gradlew :mcp:shadowJar`)
- [x] Verified the original `TypedConfigMap`, `MonitorSpec`, `Cache.replicate`, `Timer`, `createTimer` failure cases now render cleanly via `cli symbols ...`
- [x] Verified constructor extraction (`RoutineRuntimeException`, `Cache`, `LdapServerOptions`)
- [x] Verified nested class lookup (`LdapServerOptions`)
- [x] Verified member fallback (`get-symbol createCache`, `get-symbol BaseService.createTimer`)
- [x] Verified doc resolution (`docs read tracing.md`, `docs read v39-upgrade-notes.md`, ambiguity error path)
- [x] Verified CLI aliases (`symbols get`, `symbols list`, `docs get`)
- [x] Verified launcher `$JAVA_HOME` fallback path produces actionable error when neither `java` nor `JAVA_HOME` is set
- [x] Verified `.java` indexing through live MCP path: `CollectionUtils` / `JSONSerializer` / `RoutineException` (kind=interface) all resolve via `search-symbols` and `get-members`; regression-checked existing Groovy symbols (`BaseService` + member-fallback for `createCache`) still work
- [x] Re-ran independent-agent experiment: clean across all 4 tasks

🤖 Generated with Claude Opus 4.7
