### PR TITLE
Add service.build.id to OTLP resource attributes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -20,7 +20,7 @@
       }
     },
     "jetbrains": {
-      "url": "http://localhost:64342/sse",
+      "url": "http://localhost:${JETBRAINS_MCP_PORT:-64342}/sse",
       "type": "sse"
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 40.0-SNAPSHOT - unreleased
+
+### 🎁 New Features
+
+* OTLP exports now include a `service.build.id` resource attribute alongside `service.version`.
+
 ## 39.0.1 - 2026-04-30
 
 ### 🐞 Bug Fixes

--- a/grails-app/init/io/xh/hoist/ClusterConfig.groovy
+++ b/grails-app/init/io/xh/hoist/ClusterConfig.groovy
@@ -94,9 +94,10 @@ class ClusterConfig {
         [
             'service.name'               : appCode,
             'service.instance.id'        : instanceName,
-            'deployment.environment.name' : envName,
-            'service.version'            : appVersion
-        ]
+            'deployment.environment.name': envName,
+            'service.version'            : appVersion,
+            'service.build.id'           : appBuild != 'UNKNOWN' ? appBuild : null
+        ].findAll { it.value != null }
     }
 
     /**

--- a/grails-app/services/io/xh/hoist/telemetry/trace/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/trace/TraceService.groovy
@@ -237,7 +237,7 @@ class TraceService extends BaseService implements ApplicationListener<SpringAppl
      * Cross-cutting tags stamped on every span — both server-generated
      * (via {@link ExportProcessor#onStart}) and client-relayed (via {@link ClientSpanData}).
      *
-     * Note: must never generate spans itself to avoid infinitee recursion.  Keep simple.
+     * Note: must never generate spans itself to avoid infinite recursion.  Keep simple.
      */
     private Map<String, ?> hoistTags() {
         def identityService = Utils.identityService,


### PR DESCRIPTION
## Summary

Adds `service.build.id` (from `Utils.appBuild`) to the resource attributes returned by `ClusterConfig.getOtelResourceAttributes()`, alongside the existing `service.version`. Omitted when the build is unset or `'UNKNOWN'`. 

## Followup worth considering (separate issue)

While making this change we noticed our spans aren't really set up to surface client/server version mismatches. Today the server unilaterally tags `service.version` (and now `service.build.id`) based on its own build, with nothing on the span linking back to what version of hoist-react / app client actually originated the request. That makes it hard to spot or debug version-skew issues from telemetry alone. Worth tracking as its own issue.

## Test plan

- [ ] Verify OTLP exports include `service.build.id` when `appBuild` is set to a real value
- [ ] Verify the attribute is omitted when `appBuild` is `'UNKNOWN'` or null

🤖 Generated with [Claude Code](https://claude.com/claude-code)