### PR TITLE
Fix JSONClient timeout so requests actually abort on timeout (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,8 @@
 * Fixed `StandardMetricsService` JDBC pool metrics throwing NPE when JDBC tracing is enabled,
   and hardened `MetricsAdminService.listMetrics()` so a single throwing meter no longer breaks
   the admin metrics view.
-* `JSONClient` now schedules a hard `abort()` backstop on requests that have a bounded
-  `responseTimeout`, ensuring blocked socket reads are released and surfaced as a 504-flavored
-  `ExternalHttpException` rather than hanging request threads (#241).
+* `JSONClient` now hard-aborts requests that exceed their `responseTimeout`, surfacing as a
+  504 `ExternalHttpException` instead of hanging the request thread (#241).
 
 
 ## 39.0.1 - 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Fixed `StandardMetricsService` JDBC pool metrics throwing NPE when JDBC tracing is enabled,
   and hardened `MetricsAdminService.listMetrics()` so a single throwing meter no longer breaks
   the admin metrics view.
+* `JSONClient` now schedules a hard `abort()` backstop on requests that have a bounded
+  `responseTimeout`, ensuring blocked socket reads are released and surfaced as a 504-flavored
+  `ExternalHttpException` rather than hanging request threads (#241).
 
 
 ## 39.0.1 - 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,14 @@
 * Fixed `StandardMetricsService` JDBC pool metrics throwing NPE when JDBC tracing is enabled,
   and hardened `MetricsAdminService.listMetrics()` so a single throwing meter no longer breaks
   the admin metrics view.
-* `JSONClient` now hard-aborts requests that exceed their `responseTimeout`, surfacing as a
-  504 `ExternalHttpException` instead of hanging the request thread (#241).
+* `JSONClient` now exposes a single `timeoutMs` that bounds the total duration of every
+  request, settable per-client (constructor) or per-call (optional method arg). When
+  exceeded, the in-flight request is forcibly aborted and surfaces as a 504
+  `ExternalHttpException`. Replaces the prior approach of reading
+  `RequestConfig.responseTimeout` off the request — Apache HttpClient's per-phase timeouts
+  have no end-to-end deadline and have documented gaps for proxy CONNECT, TLS handshake,
+  slow-trickle responses, and retries. Constructor accepts named or positional args, e.g.
+  `new JSONClient(timeoutMs: 5000)` or `new JSONClient(customClient, 5000)` (#241).
 
 
 ## 39.0.1 - 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,10 @@
   and hardened `MetricsAdminService.listMetrics()` so a single throwing meter no longer breaks
   the admin metrics view.
 * `JSONClient` now exposes a single `timeoutMs` that bounds the total duration of every
-  request, settable per-client (constructor) or per-call (optional method arg). When
-  exceeded, the in-flight request is forcibly aborted and surfaces as a 504
-  `ExternalHttpException`. Replaces the prior approach of reading
-  `RequestConfig.responseTimeout` off the request — Apache HttpClient's per-phase timeouts
-  have no end-to-end deadline and have documented gaps for proxy CONNECT, TLS handshake,
-  slow-trickle responses, and retries. Constructor accepts named or positional args, e.g.
-  `new JSONClient(timeoutMs: 5000)` or `new JSONClient(customClient, 5000)` (#241).
-
+  request, settable per-client (constructor) or per-call (optional method arg). Offers an 
+  a simpler alternative to the prior approach of setting `RequestConfig.responseTimeout` on 
+  the request — Apache HttpClient's per-phase timeouts have no end-to-end deadline and have 
+  documented gaps.
 
 ## 39.0.1 - 2026-04-30
 

--- a/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
+++ b/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
@@ -11,15 +11,19 @@ import groovy.transform.CompileStatic
 import io.xh.hoist.exception.ExternalHttpException
 import io.xh.hoist.telemetry.trace.SpanRef
 import io.xh.hoist.json.JSONParser
+import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.core5.util.Timeout
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.xh.hoist.telemetry.ObservedRun.observe
+import static io.xh.hoist.util.DateTimeUtils.SECONDS
 import static io.xh.hoist.util.StringUtils.elide
 import static io.xh.hoist.util.Utils.traceContextService
+import static org.apache.hc.core5.http.HttpStatus.SC_GATEWAY_TIMEOUT
 import static org.apache.hc.core5.http.HttpStatus.SC_NO_CONTENT
 import static org.apache.hc.core5.http.HttpStatus.SC_OK
 
@@ -50,14 +54,13 @@ class JSONClient {
      * Execute and parse a request expected to return a single JSON object.
      */
     Map executeAsMap(HttpUriRequestBase method) {
-        def response = null
-        try {
-            response = execute(method)
-            def statusCode = response.code
-            if (statusCode == SC_NO_CONTENT) return null
-            return JSONParser.parseObject(response.entity.content)
+        TimerTask abortTask = getAbortTask(method)
+        try (CloseableHttpResponse response = execute(method)) {
+            return response.code == SC_NO_CONTENT
+                ? null
+                : JSONParser.parseObject(response.entity.content)
         } finally {
-            response?.close()
+            abortTask?.cancel()
         }
     }
 
@@ -65,14 +68,13 @@ class JSONClient {
      * Execute and parse a request expected to return an array of JSON objects.
      */
     List executeAsList(HttpUriRequestBase method) {
-        def response = null
-        try {
-            response = execute(method)
-            def statusCode = response.code
-            if (statusCode == SC_NO_CONTENT) return null
-            return JSONParser.parseArray(response.entity.content)
+        TimerTask abortTask = getAbortTask(method)
+        try (CloseableHttpResponse response = execute(method)) {
+            return response.code == SC_NO_CONTENT
+                ? null
+                : JSONParser.parseArray(response.entity.content)
         } finally {
-            response?.close()
+            abortTask?.cancel()
         }
     }
 
@@ -80,14 +82,11 @@ class JSONClient {
      * Execute request and return raw content string.
      */
     String executeAsString(HttpUriRequestBase method) {
-        def response = null
-        try {
-            response = execute(method)
-            def statusCode = response.code
-            if (statusCode == SC_NO_CONTENT) return null
-            return response.entity.content.text
+        TimerTask abortTask = getAbortTask(method)
+        try (CloseableHttpResponse response = execute(method)) {
+            return response.code == SC_NO_CONTENT ? null : response.entity.content.text
         } finally {
-            response?.close()
+            abortTask?.cancel()
         }
     }
 
@@ -95,12 +94,11 @@ class JSONClient {
      * Execute request and return status code only.
      */
     Integer executeAsStatusCode(HttpUriRequestBase method) {
-        def response = null
-        try {
-            response = execute(method)
+        TimerTask abortTask = getAbortTask(method)
+        try (CloseableHttpResponse response = execute(method)) {
             return response.code
         } finally {
-            response?.close()
+            abortTask?.cancel()
         }
     }
 
@@ -134,6 +132,10 @@ class JSONClient {
         } catch (Throwable e) {
             cause = e
             statusText = e.message
+            if (method.aborted) {
+                statusCode = SC_GATEWAY_TIMEOUT
+                statusText = 'aborted after exceeding configured timeout'
+            }
             success = false
         }
 
@@ -207,6 +209,35 @@ class JSONClient {
         } catch (Exception ignored) {
             return null
         }
+    }
+
+    //------------------------
+    // Hard abort backstop
+    //------------------------
+    // Apache HttpClient's RequestConfig timeouts (connect / response / connectionRequest) do not
+    // always reliably abort an in-flight request. We schedule an explicit `abort()` as
+    // a backstop so request threads are reliably released. See xh/hoist-core#241.
+    private static final java.util.Timer ABORT_TIMER = new java.util.Timer('JSONClientAbort', true)
+
+    private static TimerTask getAbortTask(HttpUriRequestBase method) {
+        // Only act when the caller has bounded the response phase
+        RequestConfig config = method.config
+        long responseMs = timeoutMs(config?.responseTimeout)
+        if (responseMs <= 0) return null
+
+        // Add headroom for connect time + grace period so HttpClient's own timeout machinery can fire
+        long deadlineMs = responseMs + timeoutMs(config.connectionRequestTimeout) + 5 * SECONDS
+        TimerTask task = new TimerTask() {
+            void run() {
+                try { method.abort() } catch (Throwable ignored) {}
+            }
+        }
+        ABORT_TIMER.schedule(task, deadlineMs)
+        return task
+    }
+
+    private static long timeoutMs(Timeout t) {
+        (t == null || t.disabled) ? 0L : t.toMilliseconds()
     }
 
 }

--- a/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
+++ b/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
@@ -237,7 +237,7 @@ class JSONClient {
     }
 
     private static long timeoutMs(Timeout t) {
-        (t == null || t.disabled) ? 0L : t.toMilliseconds()
+        t == null ? 0L : t.toMilliseconds()
     }
 
 }

--- a/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
+++ b/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
@@ -237,7 +237,7 @@ class JSONClient {
     }
 
     private static long timeoutMs(Timeout t) {
-        t == null ? 0L : t.toMilliseconds()
+        t?.toMilliseconds() ?: 0L
     }
 
 }

--- a/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
+++ b/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
@@ -148,11 +148,12 @@ class JSONClient {
                 statusText = statusCode.toString()
             }
         } catch (Throwable e) {
-            cause = e
-            statusText = e.message
             if (abort.fired) {
                 statusCode = SC_GATEWAY_TIMEOUT
-                statusText = "aborted after exceeding ${timeoutMs}ms timeout"
+                statusText = "Aborted after exceeding ${timeoutMs}ms timeout"
+            } else {
+                cause = e
+                statusText = e.message
             }
             success = false
         }

--- a/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
+++ b/src/main/groovy/io/xh/hoist/http/JSONClient.groovy
@@ -8,19 +8,17 @@
 package io.xh.hoist.http
 
 import groovy.transform.CompileStatic
+import groovy.transform.NamedVariant
 import io.xh.hoist.exception.ExternalHttpException
 import io.xh.hoist.telemetry.trace.SpanRef
 import io.xh.hoist.json.JSONParser
-import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
-import org.apache.hc.core5.util.Timeout
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.xh.hoist.telemetry.ObservedRun.observe
-import static io.xh.hoist.util.DateTimeUtils.SECONDS
 import static io.xh.hoist.util.StringUtils.elide
 import static io.xh.hoist.util.Utils.traceContextService
 import static org.apache.hc.core5.http.HttpStatus.SC_GATEWAY_TIMEOUT
@@ -34,6 +32,12 @@ import static org.apache.hc.core5.http.HttpStatus.SC_OK
  *
  * This wrapper also provides additional customizations around exceptions. If a response returns
  * with an HTTP status code indicating an error (i.e. *not* 200-204), the execute method will throw.
+ *
+ * Supports a single, simple {@link #timeoutMs} that bounds the total duration of
+ * any request executed by this client. This sidesteps Apache HttpClient's
+ * per-phase timeout knobs (`connect` / `connectionRequest` / `response`), which do not provide
+ * an end-to-end deadline and have known gaps for proxy CONNECT, TLS handshake, and slow-trickle
+ * scenarios. See xh/hoist-core#241.
  */
 @CompileStatic
 class JSONClient {
@@ -41,10 +45,22 @@ class JSONClient {
     private final CloseableHttpClient _client
 
     /**
-     * @param client - a preconfigured HttpClient instance, or omit for a default client.
+     * Timeout (ms) applied to every request issued by this client. Null
+     * (the default) disables the deadline. When exceeded, the in-flight request is forcibly
+     * aborted and a 504 {@link ExternalHttpException} is thrown.
      */
-    JSONClient(CloseableHttpClient client = HttpClients.createDefault()) {
+    final Long timeoutMs
+
+    /**
+     * Construct this object.
+     *
+     * @param client - a preconfigured HttpClient instance, or omit for a default client.
+     * @param timeoutMs - timeout applied to every request, or null to disable.
+     */
+    @NamedVariant
+    JSONClient(CloseableHttpClient client = HttpClients.createDefault(), Long timeoutMs = null) {
         this._client = client
+        this.timeoutMs = timeoutMs
     }
 
     //--------------------------------------------------
@@ -52,53 +68,55 @@ class JSONClient {
     //---------------------------------------------------
     /**
      * Execute and parse a request expected to return a single JSON object.
+     * @param timeoutMs - per-call timeout override; defaults to this client's timeoutMs.
      */
-    Map executeAsMap(HttpUriRequestBase method) {
-        TimerTask abortTask = getAbortTask(method)
-        try (CloseableHttpResponse response = execute(method)) {
+    Map executeAsMap(HttpUriRequestBase method, Long timeoutMs = this.timeoutMs) {
+        try (AbortHandle abort = scheduleAbort(method, timeoutMs)
+             CloseableHttpResponse response = execute(method, abort, timeoutMs)) {
             return response.code == SC_NO_CONTENT
                 ? null
                 : JSONParser.parseObject(response.entity.content)
-        } finally {
-            abortTask?.cancel()
         }
     }
 
     /**
      * Execute and parse a request expected to return an array of JSON objects.
+     * @param timeoutMs - per-call timeout override; defaults to this client's timeoutMs.
      */
-    List executeAsList(HttpUriRequestBase method) {
-        TimerTask abortTask = getAbortTask(method)
-        try (CloseableHttpResponse response = execute(method)) {
+    List executeAsList(HttpUriRequestBase method, Long timeoutMs = this.timeoutMs) {
+        try (
+            AbortHandle abort = scheduleAbort(method, timeoutMs)
+            CloseableHttpResponse response = execute(method, abort, timeoutMs)
+        ) {
             return response.code == SC_NO_CONTENT
                 ? null
                 : JSONParser.parseArray(response.entity.content)
-        } finally {
-            abortTask?.cancel()
         }
     }
 
     /**
      * Execute request and return raw content string.
+     * @param timeoutMs - per-call timeout override; defaults to this client's timeoutMs.
      */
-    String executeAsString(HttpUriRequestBase method) {
-        TimerTask abortTask = getAbortTask(method)
-        try (CloseableHttpResponse response = execute(method)) {
+    String executeAsString(HttpUriRequestBase method, Long timeoutMs = this.timeoutMs) {
+        try (
+            AbortHandle abort = scheduleAbort(method, timeoutMs)
+            CloseableHttpResponse response = execute(method, abort, timeoutMs)
+        ) {
             return response.code == SC_NO_CONTENT ? null : response.entity.content.text
-        } finally {
-            abortTask?.cancel()
         }
     }
 
     /**
      * Execute request and return status code only.
+     * @param timeoutMs - per-call timeout override; defaults to this client's timeoutMs.
      */
-    Integer executeAsStatusCode(HttpUriRequestBase method) {
-        TimerTask abortTask = getAbortTask(method)
-        try (CloseableHttpResponse response = execute(method)) {
+    Integer executeAsStatusCode(HttpUriRequestBase method, Long timeoutMs = this.timeoutMs) {
+        try (
+            AbortHandle abort = scheduleAbort(method, timeoutMs)
+            CloseableHttpResponse response = execute(method, abort, timeoutMs)
+        ) {
             return response.code
-        } finally {
-            abortTask?.cancel()
         }
     }
 
@@ -106,7 +124,7 @@ class JSONClient {
     //------------------------
     // Implementation
     //------------------------
-    private CloseableHttpResponse execute(HttpUriRequestBase method) {
+    private CloseableHttpResponse execute(HttpUriRequestBase method, AbortHandle abort, Long timeoutMs) {
         CloseableHttpResponse ret = null
         Throwable cause = null
         Integer statusCode = null
@@ -132,9 +150,9 @@ class JSONClient {
         } catch (Throwable e) {
             cause = e
             statusText = e.message
-            if (method.aborted) {
+            if (abort.fired) {
                 statusCode = SC_GATEWAY_TIMEOUT
-                statusText = 'aborted after exceeding configured timeout'
+                statusText = "aborted after exceeding ${timeoutMs}ms timeout"
             }
             success = false
         }
@@ -212,32 +230,29 @@ class JSONClient {
     }
 
     //------------------------
-    // Hard abort backstop
+    // Timeout abort
     //------------------------
-    // Apache HttpClient's RequestConfig timeouts (connect / response / connectionRequest) do not
-    // always reliably abort an in-flight request. We schedule an explicit `abort()` as
-    // a backstop so request threads are reliably released. See xh/hoist-core#241.
     private static final java.util.Timer ABORT_TIMER = new java.util.Timer('JSONClientAbort', true)
 
-    private static TimerTask getAbortTask(HttpUriRequestBase method) {
-        // Only act when the caller has bounded the response phase
-        RequestConfig config = method.config
-        long responseMs = timeoutMs(config?.responseTimeout)
-        if (responseMs <= 0) return null
-
-        // Add headroom for connect time + grace period so HttpClient's own timeout machinery can fire
-        long deadlineMs = responseMs + timeoutMs(config.connectionRequestTimeout) + 5 * SECONDS
-        TimerTask task = new TimerTask() {
+    private static AbortHandle scheduleAbort(HttpUriRequestBase method, Long timeoutMs) {
+        AbortHandle handle = new AbortHandle()
+        if (!timeoutMs || timeoutMs <= 0) return handle
+        handle.task = new TimerTask() {
             void run() {
+                handle.fired = true
                 try { method.abort() } catch (Throwable ignored) {}
             }
         }
-        ABORT_TIMER.schedule(task, deadlineMs)
-        return task
+        ABORT_TIMER.schedule(handle.task, timeoutMs)
+        return handle
     }
 
-    private static long timeoutMs(Timeout t) {
-        t?.toMilliseconds() ?: 0L
-    }
+    private static class AbortHandle implements AutoCloseable {
+        volatile boolean fired = false
+        TimerTask task
 
+        void close() {
+            task?.cancel()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #241.

`JSONClient` now exposes a single `timeoutMs` that bounds the total duration of every request issued by the client — settable per-client (constructor) or overridden per-call (optional method arg). When exceeded, the in-flight request is forcibly aborted and surfaces as `ExternalHttpException` with `SC_GATEWAY_TIMEOUT` (504).

This replaces the earlier approach of reading `RequestConfig.responseTimeout` off the request and computing a backstop from HttpClient's per-phase knobs. Apache HttpClient's per-phase timeouts (`connect` / `connectionRequest` / `response`) provide no end-to-end deadline and have documented gaps for proxy CONNECT, TLS handshake, slow-trickle response bodies, and retry multiplication. A single explicit abort scheduled at `now + timeoutMs` is the simple guarantee callers actually want.

## API

```groovy
// Constructor — named or positional via @NamedVariant
new JSONClient()
new JSONClient(customClient)
new JSONClient(customClient, 5000)
new JSONClient(timeoutMs: 5000)
new JSONClient(client: customClient, timeoutMs: 5000)

// Per-call override
client.executeAsMap(request)              // uses client default
client.executeAsMap(request, 1000)        // override
```

`timeoutMs` is `Long` — null (default) disables the timeout.

## Notes

* Single shared static daemon `Timer` for scheduling aborts. Abort tasks are non-blocking so the single-thread-Timer caveat doesn't apply.
* Convenience methods use try-with-resources composing `AbortHandle` (a small AutoCloseable) and `CloseableHttpResponse`. Replaces the previous `try/finally { abortTask?.cancel() }` shape.
* `AbortHandle.fired` is set only by *our* scheduled task — so third-party `method.abort()` calls don't get mislabeled as our timeout.
* Callers who do not configure `timeoutMs` see no behavior change (null = disabled).

## Test plan

- [ ] Manual: hit a deliberately stalled endpoint with `new JSONClient(timeoutMs: 100)`; confirm the request aborts at deadline and surfaces as 504 `ExternalHttpException`.
- [ ] Manual: confirm normal successful + error-status responses are unchanged.
- [ ] Manual: confirm callers using `new JSONClient()` with no timeout see no behavior change.
- [ ] Manual: confirm per-call override (`executeAsMap(method, 50)`) takes precedence over the client's default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)