### PR TITLE
Merge user-comment supplements onto prior client error rows (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * OTLP exports now include a `service.build.id` resource attribute alongside `service.version`.
 * `RestController` `update` now also accepts `PATCH` (in addition to `PUT`).
+* When a user submits a comment via the exception dialog, `TrackService` now merges it onto the
+  matching prior auto-logged client error (same user, same `data.error`, within 30m) instead of
+  creating a duplicate row. `ClientErrorEmailService` sends a follow-up "User Comment Added"
+  email on the new `xhClientErrorCommented` topic.
 
 ### 🤖 AI Docs + Tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 
 * OTLP exports now include a `service.build.id` resource attribute alongside `service.version`.
 * `RestController` `update` now also accepts `PATCH` (in addition to `PUT`).
-* When a user submits a comment via the exception dialog, `TrackService` now merges it onto the
-  matching prior auto-logged client error (same user, same `data.error`, within 30m) instead of
-  creating a duplicate row. `ClientErrorEmailService` sends a follow-up "User Comment Added"
-  email on the new `xhClientErrorCommented` topic.
+
+### 🐞 Bug Fixes
+
+* User comments submitted via the exception dialog now merge onto the matching prior auto-logged
+  client error instead of creating a duplicate row + duplicate email.
 
 ### 🤖 AI Docs + Tooling
 

--- a/grails-app/services/io/xh/hoist/track/ClientErrorEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/track/ClientErrorEmailService.groovy
@@ -45,6 +45,11 @@ class ClientErrorEmailService extends BaseService {
             delay: 15 * DateTimeUtils.SECONDS,
             primaryOnly: true
         )
+        subscribeToTopic(
+            topic: 'xhClientErrorCommented',
+            primaryOnly: true,
+            onMessage: { TrackLog tl -> sendCommentMail(tl) }
+        )
     }
 
     //------------------
@@ -82,6 +87,16 @@ class ClientErrorEmailService extends BaseService {
             emailService.sendEmail(async: true, to: to, subject: subject, html: html)
             emailsSent++
         }
+    }
+
+    // Sent immediately when a user-comment supplement is merged onto a prior client error.
+    private void sendCommentMail(TrackLog tl) {
+        def to = toAddress
+        if (!to) return
+        def subject = "$appName Client Error - User Comment Added"
+        logInfo('Sending user-comment supplement email', [trackLogId: tl.id, to: to])
+        emailService.sendEmail(async: true, to: to, subject: subject, html: formatSingle(tl))
+        emailsSent++
     }
 
     private String formatSingle(TrackLog tl, boolean withDetails = true) {

--- a/grails-app/services/io/xh/hoist/track/ClientErrorEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/track/ClientErrorEmailService.groovy
@@ -48,7 +48,7 @@ class ClientErrorEmailService extends BaseService {
         subscribeToTopic(
             topic: 'xhClientErrorCommented',
             primaryOnly: true,
-            onMessage: { TrackLog tl -> sendCommentMail(tl) }
+            onMessage: this.&sendCommentMail
         )
     }
 

--- a/grails-app/services/io/xh/hoist/track/ClientErrorEmailService.groovy
+++ b/grails-app/services/io/xh/hoist/track/ClientErrorEmailService.groovy
@@ -92,11 +92,12 @@ class ClientErrorEmailService extends BaseService {
     // Sent immediately when a user-comment supplement is merged onto a prior client error.
     private void sendCommentMail(TrackLog tl) {
         def to = toAddress
-        if (!to) return
-        def subject = "$appName Client Error - User Comment Added"
-        logInfo('Sending user-comment supplement email', [trackLogId: tl.id, to: to])
-        emailService.sendEmail(async: true, to: to, subject: subject, html: formatSingle(tl))
-        emailsSent++
+        if (to) {
+            def subject = "$appName Client Error - User Comment Added"
+            logInfo('Sending user-comment supplement email', [trackLogId: tl.id, to: to])
+            emailService.sendEmail(async: true, to: to, subject: subject, html: formatSingle(tl))
+            emailsSent++
+        }
     }
 
     private String formatSingle(TrackLog tl, boolean withDetails = true) {

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -247,11 +247,13 @@ class TrackService extends BaseService {
         Map rawData = entry.rawData as Map
         String userMessage = rawData?.userMessage
         Map errorData = rawData?.error as Map
-        if (!userMessage || !errorData) return false
+        String loadId = entry.loadId as String
+        if (!userMessage || !errorData || !loadId) return false
 
-        Date cutoff = new Date(System.currentTimeMillis() - 30 * MINUTES)
-        List<TrackLog> candidates = TrackLog.findAllByCategoryAndUsernameAndDateCreatedGreaterThanEquals(
-            'Client Error', entry.username as String, cutoff,
+        // Match within the same app load (same browser tab session) for safety.
+        Date cutoff = new Date(System.currentTimeMillis() - 15 * MINUTES)
+        List<TrackLog> candidates = TrackLog.findAllByCategoryAndUsernameAndLoadIdAndDateCreatedGreaterThanEquals(
+            'Client Error', entry.username as String, loadId, cutoff,
             [max: 10, sort: 'dateCreated', order: 'desc']
         )
         TrackLog prior = candidates.find { p ->

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -7,6 +7,7 @@
 
 package io.xh.hoist.track
 
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.transform.NamedParam
 import groovy.transform.NamedVariant
@@ -166,6 +167,10 @@ class TrackService extends BaseService {
                         TimestampedLogEntry logEntry = createLogEntry(it)
                         trackLoggingService.logEntry(logEntry)
 
+                        // If this is a user-comment supplement to a recent identical client
+                        // error, merge it onto the prior row instead of creating a duplicate.
+                        if (doPersist && tryMergeClientErrorComment(it)) return
+
                         TrackLog tl = createTrackLog(it)
                         if (doPersist && isSeverityActive(tl)) {
                             tl.save()
@@ -231,6 +236,37 @@ class TrackService extends BaseService {
             browser       : getBrowser(currentRequest),
             device        : getDevice(currentRequest)
         ]
+    }
+
+    // If `entry` is a Client Error carrying a userMessage and matching a recent prior row that
+    // lacks one, merge the comment onto that prior row and publish `xhClientErrorCommented`.
+    // Returns true if merged (caller should then skip creating a new row).
+    @CompileDynamic
+    private boolean tryMergeClientErrorComment(Map entry) {
+        if (entry.category != 'Client Error') return false
+        Map rawData = entry.rawData as Map
+        String userMessage = rawData?.userMessage
+        Map errorData = rawData?.error as Map
+        if (!userMessage || !errorData) return false
+
+        Date cutoff = new Date(System.currentTimeMillis() - 30 * MINUTES)
+        List<TrackLog> candidates = TrackLog.findAllByCategoryAndUsernameAndDateCreatedGreaterThanEquals(
+            'Client Error', entry.username as String, cutoff,
+            [max: 10, sort: 'dateCreated', order: 'desc']
+        )
+        TrackLog prior = candidates.find { p ->
+            Map d = p.dataAsObject
+            d && !d.userMessage && d.error == errorData
+        }
+        if (!prior) return false
+
+        Map merged = prior.dataAsObject
+        merged.userMessage = userMessage
+        prior.data = serialize(merged)
+        prior.save()
+        getTopic('xhClientErrorCommented').publishAsync(prior)
+        logDebug('Merged user comment onto prior client error', [trackLogId: prior.id])
+        return true
     }
 
     private TrackLog createTrackLog(Map entry) {

--- a/grails-app/services/io/xh/hoist/track/TrackService.groovy
+++ b/grails-app/services/io/xh/hoist/track/TrackService.groovy
@@ -248,12 +248,13 @@ class TrackService extends BaseService {
         String userMessage = rawData?.userMessage
         Map errorData = rawData?.error as Map
         String loadId = entry.loadId as String
+        String username = entry.username as String
         if (!userMessage || !errorData || !loadId) return false
 
         // Match within the same app load (same browser tab session) for safety.
         Date cutoff = new Date(System.currentTimeMillis() - 15 * MINUTES)
         List<TrackLog> candidates = TrackLog.findAllByCategoryAndUsernameAndLoadIdAndDateCreatedGreaterThanEquals(
-            'Client Error', entry.username as String, loadId, cutoff,
+            'Client Error', username, loadId, cutoff,
             [max: 10, sort: 'dateCreated', order: 'desc']
         )
         TrackLog prior = candidates.find { p ->


### PR DESCRIPTION
Closes #352.

When the exception dialog auto-logs a client error, then the user submits a comment via the same dialog, hoist-react makes two `track()` calls — one without `userMessage`, one with. Result: two TrackLog rows for one logical error, and `ClientErrorEmailService` sends two emails (the first lacking the user's message).

This change detects the supplement in `TrackService.trackAll`: when an incoming Client Error entry carries a `userMessage` and a recent (15m) prior row exists for the **same user, same loadId**, with byte-identical `data.error` and no existing `userMessage`, the comment is merged onto the prior row and a new `xhClientErrorCommented` cluster topic is published. `ClientErrorEmailService` subscribes (primary-only) and sends a single "User Comment Added" follow-up email.

## Match key

- `category == 'Client Error'`
- same `username`
- same `loadId` (so we are guaranteed it is the same browser tab session)
- `dateCreated` within last 15 minutes
- prior row has no `userMessage`
- prior row's `data.error` is structurally equal to the incoming `data.error` (Groovy Map equality on the sanitized exception payload — byte-identical because both calls go through `sanitizeException` on the same `HoistException` instance).

Bounded to 10 candidate rows. Anything missing → fall through to the existing path and create a new row, no behavior change.

## Test plan

- [x] Trigger an error with `logOnServer: true`, dismiss the dialog without commenting → one TrackLog row, one email (existing behavior).
- [x] Trigger an error with `logOnServer: true`, type a comment and Send → one TrackLog row with `userMessage` populated, two emails (the original digest + a "User Comment Added" follow-up).
- [x] Refresh the tab between auto-log and Send (different `loadId`) → two rows, no merge (correct, comment is a different session).
- [x] Two distinct errors in the same session, both commented → two rows, two follow-up emails.