### PR TITLE
Grails 7.1 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   Timer-level options centrally via `MetricsService.configureTimer` / `registerTimer` (see below).
 * `ObservedRun.span` / `BaseService.span` now use named args (e.g. `span(name: ..., tags: ...)`),
   or a bare name string (e.g. `span('processOrder')`).
+* Apps must add `opentelemetry.version=1.62.0` to their `gradle.properties`.
 
 ### 🎁 New Features
 
@@ -26,6 +27,15 @@
   `failure` based on whether the closure threw, making it trivial to slice timings and counts
   by success rate.
 * Added new `/xh/recordMetrics` endpoint to support client-side metrics in `hoist-react >= 86.0`.
+
+
+### 📚 Libraries
+
+* Grails `7.0.9 → 7.1.1`
+* Hazelcast `5.6.0 → 5.7.0`
+* commons-io `2.21.0 → 2.22.0`
+* OpenTelemetry BOM `1.61.0 → 1.62.0`
+* opentelemetry-jdbc `2.26.1-alpha → 2.27.0-alpha`
 
 ## 39.1.0 - 2026-05-12
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,9 +84,9 @@ dependencies {
     api "com.github.java-json-tools:json-patch:1.13"
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     api "com.jayway.jsonpath:json-path:2.9.0"
-    api "commons-io:commons-io:2.21.0"
+    api "commons-io:commons-io:2.22.0"
     api "org.apache.directory.api:api-all:2.1.7"
-    api "org.apache.httpcomponents.client5:httpclient5:5.5"
+    api "org.apache.httpcomponents.client5:httpclient5"
     api "org.apache.poi:poi-ooxml-full:5.5.1"
     api "org.apache.poi:poi-ooxml:5.5.1"
     api "org.apache.poi:poi:5.5.1"
@@ -96,26 +96,16 @@ dependencies {
     api "io.micrometer:micrometer-registry-prometheus"
     api "io.micrometer:micrometer-registry-otlp"
 
-    api platform("io.opentelemetry:opentelemetry-bom:1.61.0")
     api "io.opentelemetry:opentelemetry-sdk"
     api "io.opentelemetry:opentelemetry-exporter-otlp"
     api "io.opentelemetry:opentelemetry-exporter-common"
     api "io.opentelemetry:opentelemetry-context"
-    api "io.opentelemetry.instrumentation:opentelemetry-jdbc:2.26.1-alpha"
-    // Required transitively by opentelemetry-jdbc (via opentelemetry-api-incubator's
-    api "io.opentelemetry:opentelemetry-common"
+    api "io.opentelemetry.instrumentation:opentelemetry-jdbc:2.27.0-alpha"
 
     // Workaround needed by micrometer-registry-otlp at compile time
     api "io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha"
 
-    // Workaround needed by opentelemetry exporter
-    api "io.opentelemetry:opentelemetry-exporter-sender-okhttp"
-
 }
-
-// Override the OTel version managed by Spring Boot's BOM (which pins 1.49.0). The
-// opentelemetry-jdbc:2.26.1-alpha instrumentation requires >= 1.60.1
-ext['opentelemetry.version'] = '1.61.0'
 
 tasks.withType(GroovyCompile) {
     configure(groovyOptions) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
 xhReleaseVersion=40.0-SNAPSHOT
 
-grailsVersion=7.0.9
+grailsVersion=7.1.1
 
-hazelcast.version=5.6.0
+hazelcast.version=5.7.0
+opentelemetry.version=1.62.0
 
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/grails-app/controllers/io/xh/hoist/HoistInterceptor.groovy
+++ b/grails-app/controllers/io/xh/hoist/HoistInterceptor.groovy
@@ -74,10 +74,10 @@ class HoistInterceptor implements LogSupport {
             def ann = annotations.findResult {method.getAnnotation(it)} ?: annotations.findResult {clazz.getAnnotation(it)}
             if (
                 (ann instanceof AccessAll) ||
-                (ann instanceof AccessRequiresRole && user?.hasRole(ann.value() as String)) ||
-                (ann instanceof AccessRequiresAnyRole  && user?.hasAnyRole(ann.value() as String[])) ||
-                (ann instanceof AccessRequiresAllRoles && user?.hasAllRoles(ann.value() as String[])) ||
-                (ann instanceof Access && user?.hasAllRoles(ann.value() as String[]))
+                (ann instanceof AccessRequiresRole     && user?.hasRole(((AccessRequiresRole) ann).value())) ||
+                (ann instanceof AccessRequiresAnyRole  && user?.hasAnyRole(((AccessRequiresAnyRole) ann).value())) ||
+                (ann instanceof AccessRequiresAllRoles && user?.hasAllRoles(((AccessRequiresAllRoles) ann).value())) ||
+                (ann instanceof Access                 && user?.hasAllRoles(((Access) ann).value()))
             ) return true
 
             def username = user?.username ?: 'UNKNOWN'
@@ -106,7 +106,7 @@ class HoistInterceptor implements LogSupport {
     }
 
     private boolean isActuator(HttpServletRequest req) {
-        req?.requestURI.startsWith('/actuator/')
+        req?.requestURI?.startsWith('/actuator/')
     }
 
 }

--- a/grails-app/services/io/xh/hoist/admin/ConnectionPoolMonitoringService.groovy
+++ b/grails-app/services/io/xh/hoist/admin/ConnectionPoolMonitoringService.groovy
@@ -8,14 +8,15 @@
 package io.xh.hoist.admin
 
 import io.xh.hoist.BaseService
+import io.xh.hoist.config.ConfigService
 import io.xh.hoist.exception.DataNotAvailableException
 import org.apache.tomcat.jdbc.pool.DataSource as PooledDataSource
 import org.apache.tomcat.jdbc.pool.PoolConfiguration
-import org.springframework.boot.jdbc.DataSourceUnwrapper
 
 import javax.sql.DataSource
 import java.util.concurrent.ConcurrentHashMap
 
+import static io.xh.hoist.util.DataSourceUtils.findPooledDataSource
 import static io.xh.hoist.util.DateTimeUtils.SECONDS
 import static io.xh.hoist.util.DateTimeUtils.getHOURS
 import static io.xh.hoist.util.DateTimeUtils.intervalElapsed
@@ -28,15 +29,18 @@ import static java.lang.System.currentTimeMillis
  */
 class ConnectionPoolMonitoringService extends BaseService {
 
-    def configService,
-        dataSource
+    ConfigService configService
+    DataSource dataSource
 
     private Map<Long, Map> _snapshots = new ConcurrentHashMap()
     private Date _lastInfoLogged
-    private PooledDataSource _pooledDataSource
-    private boolean unwrapAttempted = false
+    private PooledDataSource pooledDataSource
 
     void init() {
+        pooledDataSource = findPooledDataSource(dataSource)
+        if (!pooledDataSource) {
+            logError("Failed to unwrap primary Datasource to org.apache.tomcat.jdbc.pool.DataSource - cannot monitor connection pool usage.")
+        }
         createTimer(
             name: 'takeSnapshot',
             runFn: this.&takeSnapshot,
@@ -102,7 +106,7 @@ class ConnectionPoolMonitoringService extends BaseService {
      */
     Map resetStats() {
         ensureEnabled()
-        pooledDataSource.pool.resetStats()
+        pooledDataSource?.pool?.resetStats()
         takeSnapshot()
     }
 
@@ -113,30 +117,18 @@ class ConnectionPoolMonitoringService extends BaseService {
         def ds = pooledDataSource
         return [
             timestamp: currentTimeMillis(),
-            size: ds.size,
-            active: ds.active,
-            idle: ds.idle,
-            waitCount: ds.waitCount,
-            borrowed: ds.borrowedCount,
-            returned: ds.returnedCount,
-            created: ds.createdCount,
-            released: ds.releasedCount,
-            reconnected: ds.reconnectedCount,
-            removeAbandoned: ds.removeAbandonedCount,
-            releasedIdle: ds.releasedIdleCount
+            size: ds?.size,
+            active: ds?.active,
+            idle: ds?.idle,
+            waitCount: ds?.waitCount,
+            borrowed: ds?.borrowedCount,
+            returned: ds?.returnedCount,
+            created: ds?.createdCount,
+            released: ds?.releasedCount,
+            reconnected: ds?.reconnectedCount,
+            removeAbandoned: ds?.removeAbandonedCount,
+            releasedIdle: ds?.releasedIdleCount
         ]
-    }
-
-    private PooledDataSource getPooledDataSource() {
-        if (!_pooledDataSource && !unwrapAttempted) {
-            try {
-                unwrapAttempted = true
-                _pooledDataSource = DataSourceUnwrapper.unwrap(dataSource as DataSource, PooledDataSource.class)
-            } catch (e) {
-                logError("Failed to unwrap primary Datasource to org.apache.tomcat.jdbc.pool.DataSource - cannot monitor connection pool usage.", e)
-            }
-        }
-        return _pooledDataSource
     }
 
     private void ensureEnabled() {

--- a/grails-app/services/io/xh/hoist/telemetry/metric/impl/BuiltInMetricsService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/metric/impl/BuiltInMetricsService.groovy
@@ -24,9 +24,9 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics
 import io.micrometer.core.instrument.binder.tomcat.TomcatMetrics
 import io.xh.hoist.BaseService
 import io.xh.hoist.telemetry.metric.MetricsService
-import org.apache.tomcat.jdbc.pool.DataSource as PooledDataSource
-
 import javax.sql.DataSource
+
+import static io.xh.hoist.util.DataSourceUtils.findPooledDataSource
 
 /**
  * Registers standard infrastructure metrics with the application's
@@ -41,7 +41,7 @@ import javax.sql.DataSource
 @CompileStatic
 class BuiltInMetricsService extends BaseService {
 
-    def dataSource
+    DataSource dataSource
 
     MetricsService metricsService
 
@@ -86,9 +86,7 @@ class BuiltInMetricsService extends BaseService {
      * Includes standard + tomcat pool specific
      */
     private void registerConnectionPoolMeters() {
-        def ds = dataSource as DataSource
-
-        ds = ds.isWrapperFor(PooledDataSource) ? ds.unwrap(PooledDataSource) : null
+        def ds = findPooledDataSource(dataSource)
         if (!ds) {
             logWarn("Primary DataSource not org.apache.tomcat.jdbc.pool.DataSource - JDBC metrics unavailable.")
             return

--- a/grails-app/services/io/xh/hoist/telemetry/trace/TraceService.groovy
+++ b/grails-app/services/io/xh/hoist/telemetry/trace/TraceService.groovy
@@ -209,11 +209,12 @@ class TraceService extends BaseService implements ApplicationListener<SpringAppl
      * @internal
      */
     void submitClientSpans(List<Map> spans) {
-        def resource = _resource
-        if (!resource) return
+        def resource = _resource,
+            processor = exportProcessor
+        if (!resource || !processor) return
         def extraTags = hoistTags()
         spans.each {
-            exportProcessor.submitSpan(new ClientSpanData(it, resource, extraTags))
+            processor.submitSpan(new ClientSpanData(it, resource, extraTags))
         }
     }
 
@@ -301,6 +302,7 @@ class TraceService extends BaseService implements ApplicationListener<SpringAppl
         _otelSdk?.sdkTracerProvider?.shutdown()
         _otelSdk = null
         _resource = null
+        exportProcessor = null
     }
 
     /**

--- a/src/main/groovy/io/xh/hoist/util/DataSourceUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/DataSourceUtils.groovy
@@ -1,0 +1,46 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+
+package io.xh.hoist.util
+
+import groovy.transform.CompileStatic
+import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource
+import org.apache.tomcat.jdbc.pool.DataSource as PooledDataSource
+import org.springframework.jdbc.datasource.DelegatingDataSource
+
+import javax.sql.DataSource
+
+@CompileStatic
+class DataSourceUtils {
+
+    /**
+     * Walk the proxy/wrap chain rooted at {@code ds} and return the underlying Tomcat JDBC pool,
+     * or {@code null} if none is found.
+     *
+     * Looks through Spring's {@link DelegatingDataSource} chain and the JDBC tracing layer
+     * ({@link OpenTelemetryDataSource}, whose wrapped pool is held in a private {@code delegate}
+     * field with no public accessor). Standard JDBC {@code unwrap}/{@code isWrapperFor} can't be
+     * used here because Tomcat's {@code DataSourceProxy} stubs both to always return null/false.
+     */
+    static PooledDataSource findPooledDataSource(DataSource ds) {
+        while (ds != null) {
+            if (ds instanceof PooledDataSource) return ds
+            ds = nextLayer(ds)
+        }
+        return null
+    }
+
+    private static DataSource nextLayer(DataSource ds) {
+        if (ds instanceof DelegatingDataSource) return ds.targetDataSource
+        if (ds instanceof OpenTelemetryDataSource) {
+            def f = OpenTelemetryDataSource.getDeclaredField('delegate')
+            f.accessible = true
+            return f.get(ds) as DataSource
+        }
+        return null
+    }
+}

--- a/src/main/resources/hazelcast-hibernate.xml
+++ b/src/main/resources/hazelcast-hibernate.xml
@@ -7,7 +7,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.6.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.7.xsd">
 
     <instance-name>${io.xh.hoist.hzInstanceName} </instance-name>
 </hazelcast>


### PR DESCRIPTION
## Summary
- Upgrade to Grails 7.1 (Spring Boot 3.5, Hibernate 5).
- Upgrade Open Telmetry, Hazelcast and other Misc.
- Fix `PooledDataSource` unwrapping so JDBC metrics + pool monitoring continue to work when `JdbcTraceService` wraps the chain with `OpenTelemetryDataSource`. New shared `DataSourceUtils.findPooledDataSource()` walks past Spring's `DelegatingDataSource` chain and reflects through `OpenTelemetryDataSource.delegate`. Resolution is eager in both services for consistency.

## Test plan
- [ ] App boots cleanly with no `Primary DataSource not org.apache.tomcat.jdbc.pool.DataSource` warning
- [ ] `jdbc.connections.*` gauges and counters appear in metrics
- [ ] Admin console connection pool monitoring shows live snapshots
- [ ] Behavior verified with JDBC tracing both enabled and disabled