### PR TITLE
Defend WebSocketService channel routing against malformed keys (40.0.3 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 41.0-SNAPSHOT - unreleased
 
+## 40.0.3 - 2026-05-20
+
+### 🐞 Bug Fixes
+
+* Hardened `WebSocketService` channel-routing against malformed channel keys (e.g. presented by older clients that predate the current `{authUsername}|{instanceName}|{uuid}` format). `pushToChannel`, `pushToChannels`, and `hasChannel` now silently drop unparseable keys instead of throwing `ArrayIndexOutOfBoundsException` out of the private `instanceFromKey` helper.
+
 ## 40.0.2 - 2026-05-19
 
 ### 🐞 Bug Fixes

--- a/grails-app/services/io/xh/hoist/websocket/WebSocketService.groovy
+++ b/grails-app/services/io/xh/hoist/websocket/WebSocketService.groovy
@@ -117,7 +117,9 @@ class WebSocketService extends BaseService implements EventPublisher {
         if (!channelKeys) return
 
         def msg = serialize(topic, data),
-            byInstance = channelKeys.groupBy { instanceFromKey(it) }
+            byInstance = channelKeys
+                .findAll { instanceFromKey(it) != null }
+                .groupBy { instanceFromKey(it) }
 
         asyncEach(byInstance.entrySet()) { Entry e ->
             def instance = e.key as String,
@@ -185,6 +187,7 @@ class WebSocketService extends BaseService implements EventPublisher {
      */
     boolean hasChannel(String channelKey) {
         def instance = instanceFromKey(channelKey)
+        if (instance == null) return false
         if (instance == instanceName) return hasLocalChannel(channelKey)
 
         def result = runOnInstance(this.&hasLocalChannel, instance, [channelKey])
@@ -277,8 +280,14 @@ class WebSocketService extends BaseService implements EventPublisher {
         )
     }
 
+    // Channel keys are produced by HoistWebSocketChannel in the form
+    // `{authUsername}|{instanceName}|{uuid}`. Defensive against keys from older
+    // clients (or other malformed input) that may not match this format - return
+    // null rather than throwing, so callers can silently drop the request.
     private String instanceFromKey(String channelKey) {
-        channelKey.split('\\|')[1]
+        if (!channelKey) return null
+        def parts = channelKey.split('\\|')
+        parts.length >= 2 ? parts[1] : null
     }
 
     private void pushInternal(Collection<String> channelKeys, TextMessage textMessage) {


### PR DESCRIPTION
## Summary

Production logs show `ArrayIndexOutOfBoundsException` escaping `WebSocketService.instanceFromKey` when an older client (predating the current `{authUsername}|{instanceName}|{uuid}` channel-key format) calls into the push / `hasChannel` APIs and the resulting key has no `|` separator. `channelKey.split('\|')[1]` then throws.

Three call sites are affected:

- `pushToChannels` — `channelKeys.groupBy { instanceFromKey(it) }` would throw on any malformed key in the collection, dropping pushes for valid keys in the same call.
- `hasChannel` — would throw when callers (e.g. app services pruning stale subscriptions) presented an old key.
- `hasLocalChannel` — already harmless once `instanceFromKey` is hardened (null `!= instanceName`).

## Fix

Make `instanceFromKey` defensive: return `null` on empty input or when the key splits into fewer than two parts, rather than indexing the array unconditionally. Update callers to handle `null` consistently with the documented "silently drop unknown/disconnected client" contract:

- `pushToChannels` filters out unparseable keys before grouping by instance.
- `hasChannel` returns `false` for unparseable keys (so they look like "not connected" — the existing semantics for stale keys).

The private helper now carries a short comment explaining why the guard exists (older client compatibility), so the intent is preserved for future readers.

## Release

Staged as patch release **40.0.3** under a new CHANGELOG section dated 2026-05-20, ready to ship post review. `gradle.properties` is left at `41.0-SNAPSHOT` for the release tooling to bump as part of the normal "Prepare changelog for release" step.

## Test plan

- [x] `./gradlew assemble` passes locally on JDK 25.
- [ ] No new unit tests — `WebSocketService` is not currently covered by a test suite. Logic is exercised by ordinary client connections; the new guard is a pure null-safety addition with no behavioral change for well-formed keys.
- [ ] Spot-check on staging: connect an older client build and confirm push attempts to its (malformed) channel key are now silently dropped rather than logging stack traces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAQTfV2iEHFdK6hWfco6t6)_