### PR TITLE
Add ClusterService.isHazelcastRunning local member health signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Disabled three unused Spring Boot auto-configurations (`HttpClientAutoConfiguration`, `RestClientAutoConfiguration`,
  `RestTemplateAutoConfiguration`) to avoid coupling to a specific Apache HttpClient version.
+* Added `ClusterService.isHazelcastRunning` to report local Hazelcast member liveness, suitable for backing a
+ Kubernetes liveness probe that can detect and restart a "zombie" instance whose Hazelcast member has died.
 
 ## 40.1.0 - 2026-06-04
 

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -61,6 +61,42 @@ Application Start
 | `RUNNING` | Fully ready, accepting requests |
 | `STOPPING` | Shutting down, rejecting new requests |
 
+### Health Signals
+
+`instanceState` tracks the coarse **application** lifecycle — it is set to `RUNNING` once at
+startup and only leaves that state on a deliberate shutdown. It does **not** reflect the health of
+the underlying Hazelcast member: an instance whose Hazelcast member has died (for example after an
+`OutOfMemoryError`) can keep reading `RUNNING` while the JVM continues to serve HTTP — a "zombie"
+instance.
+
+For that case, `ClusterService.isHazelcastRunning` reports whether **this instance's own** Hazelcast
+member is still live, reading the member's lifecycle state directly:
+
+```groovy
+boolean healthy = clusterService.isHazelcastRunning
+```
+
+It is cheap and non-throwing (returns `false` rather than propagating any error), making it suitable
+for a high-frequency health endpoint. The value is also included in `ClusterService.getAdminStats()`.
+
+Hoist already attempts a graceful self-heal: `ClusterService` registers a Hazelcast
+`LifecycleListener` that terminates the app if the member shuts down unexpectedly. That path is
+cooperative, however, and has been observed to stall under heap exhaustion — precisely the scenario
+it should catch. A Kubernetes **liveness probe** wired to a status endpoint backed by
+`isHazelcastRunning` provides a non-cooperative backstop: a wedged member reads as not-running, and
+k8s restarts the pod via SIGKILL without needing any cooperation from the stalled JVM.
+
+> **Caveat — pair a liveness probe with a startup probe.** `isHazelcastRunning` returns `false`
+> during startup, before the Hazelcast member is up. If a liveness probe is configured without a
+> Kubernetes `startupProbe` (or a sufficient `initialDelaySeconds`), k8s will kill instances
+> mid-boot in a crash loop. Gate the liveness probe behind a startup probe so the instance is given
+> time to initialize Hazelcast before liveness is enforced.
+
+Note this is a strict improvement over `instanceState` and the cooperative listener, not a
+universal detector: an instance can still be heap-thrashing while its Hazelcast member remains
+technically active, in which case `isHazelcastRunning` reports `true`. No single cheap flag can
+catch every degraded state.
+
 ### Primary Instance
 
 The **primary instance** is the oldest member of the Hazelcast cluster. It handles tasks that
@@ -89,6 +125,7 @@ framework.
 |-----------------|-------------|
 | `isPrimary` | `true` if this is the oldest cluster member |
 | `instanceState` | Current instance state (`STARTING`, `RUNNING`, `STOPPING`) |
+| `isHazelcastRunning` | `true` if this instance's local Hazelcast member is live (see [Health Signals](#health-signals)) |
 | `localName` | Human-readable name for this instance |
 | `hzInstance` | Direct access to the Hazelcast instance (rarely needed) |
 | `ensureRunning()` | Throws if instance is not in `RUNNING` state |

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -78,7 +78,7 @@
             "mcpCategory": "package",
             "viewerCategory": "core-features",
             "description": "Hazelcast-based multi-instance coordination and distributed data structures.",
-            "keywords": ["ClusterService", "Cache", "CachedValue", "IMap", "ReplicatedMap", "Topic", "primaryOnly"]
+            "keywords": ["ClusterService", "Cache", "CachedValue", "IMap", "ReplicatedMap", "Topic", "primaryOnly", "isHazelcastRunning", "instanceState", "liveness probe", "health"]
         },
         {
             "id": "docs/activity-tracking.md",

--- a/grails-app/services/io/xh/hoist/cluster/ClusterService.groovy
+++ b/grails-app/services/io/xh/hoist/cluster/ClusterService.groovy
@@ -175,6 +175,24 @@ class ClusterService extends BaseService implements ApplicationListener<Applicat
     }
 
     /**
+     * Is this instance's local Hazelcast member running - i.e. not shut down or wedged?
+     *
+     * Unlike {@link #instanceState}, which reflects the coarse app lifecycle and remains RUNNING
+     * even after the underlying Hazelcast member has died (e.g. following an OOM), this reflects
+     * the actual liveness of the embedded Hazelcast member. Intended as a cheap, non-throwing
+     * signal for external health checks such as a Kubernetes liveness probe, which can restart a
+     * "zombie" instance whose Hazelcast member has stopped but whose JVM continues serving HTTP.
+     */
+    boolean getIsHazelcastRunning() {
+        try {
+            return hzInstance?.lifecycleService?.running ?: false
+        } catch (Throwable t) {
+            // NotActive / wedged member / null - treat as not running
+            return false
+        }
+    }
+
+    /**
      * Shutdown this instance of the app.
      *
      * @param delay - optional delay to allow in progress requests to complete cleanly.
@@ -302,11 +320,12 @@ class ClusterService extends BaseService implements ApplicationListener<Applicat
     }
 
     Map getAdminStats() {[
-        clusterId   : cluster.clusterState.id,
-        instanceName: instanceName,
-        primaryName : primaryName,
-        isPrimary   : isPrimary,
-        members     : cluster.members.collect { it.getAttribute('instanceName') }
+        clusterId          : cluster.clusterState.id,
+        instanceName       : instanceName,
+        primaryName        : primaryName,
+        isPrimary          : isPrimary,
+        isHazelcastRunning : isHazelcastRunning,
+        members            : cluster.members.collect { it.getAttribute('instanceName') }
     ]}
 
 


### PR DESCRIPTION
Exposes a cheap, non-throwing signal for whether this instance's own Hazelcast member is live — intended to back a Kubernetes **liveness** probe that can detect and restart a "zombie" instance whose Hazelcast member has died (e.g. after an OOM) while the JVM keeps serving HTTP.

### Why
`instanceState` tracks only the coarse app lifecycle — it stays `RUNNING` even after the underlying Hazelcast member dies, so it can't detect this case. The existing self-heal (a `LifecycleListener` that terminates the app) is cooperative and has been observed to stall under heap exhaustion — exactly the scenario it should catch. A liveness probe reading a state flag is a non-cooperative backstop: SIGKILL needs nothing from the wedged JVM.

### Changes
* `ClusterService.isHazelcastRunning` — reads the local member's lifecycle state, null-safe and non-throwing (returns `false` on any error / before init).
* Included in `ClusterService.getAdminStats()`.
* Documented the signal + the required **startup-probe pairing** in `clustering.md` (a liveness probe without a startup probe will crash-loop on boot, since the signal is `false` before Hazelcast is up).
* Doc-registry keywords + CHANGELOG entry under 41.0-SNAPSHOT.

### Note
This is a strict improvement over `instanceState` and the cooperative listener, not a universal freeze detector — an instance heap-thrashing while its member is still technically `ACTIVE` will read `true`.

🤖 Generated with Claude Opus 4.8