### PR TITLE
Fix Cache.put passing wrong key to fireOnChange on non-cluster path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐞 Bug Fixes
 
 * Fixed `Cache.put()` passing the `Cache` instance itself (rather than the actual entry key) to `fireOnChange` on the non-cluster code path. This caused `CacheEntryChanged.key` to have the wrong type for `onChange` handlers on single-instance or `replicate: false` deployments. The cluster path via `CacheEntryListener` was already correct.
+* Fixed `ClusterConfig.getMultiInstanceEnabled()` using identity comparison (`!==`) instead of value equality (`!=`) when checking the `multiInstanceEnabled` instance config against `'false'`. The identity check meant a config value of `"false"` was never reference-equal to the string literal, so multi-instance mode could never actually be disabled via instance config.
 
 ### 📚 Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Added `ClusterService.isHazelcastRunning` to report local Hazelcast member liveness, suitable for backing a
  Kubernetes liveness probe that can detect and restart a "zombie" instance whose Hazelcast member has died.
 
+### 🐞 Bug Fixes
+
+* Fixed `Cache.put()` passing the `Cache` instance itself (rather than the actual entry key) to `fireOnChange` on the non-cluster code path. This caused `CacheEntryChanged.key` to have the wrong type for `onChange` handlers on single-instance or `replicate: false` deployments. The cluster path via `CacheEntryListener` was already correct.
+
 ### 📚 Libraries
 
 * Grails `7.1.1 → 7.2.0`

--- a/grails-app/init/io/xh/hoist/ClusterConfig.groovy
+++ b/grails-app/init/io/xh/hoist/ClusterConfig.groovy
@@ -57,7 +57,7 @@ class ClusterConfig {
      * instance config, or override this method to implement additional logic.
      */
     boolean getMultiInstanceEnabled() {
-        return getInstanceConfig('multiInstanceEnabled') !== 'false'
+        return getInstanceConfig('multiInstanceEnabled') != 'false'
     }
 
     /**

--- a/src/main/groovy/io/xh/hoist/cache/Cache.groovy
+++ b/src/main/groovy/io/xh/hoist/cache/Cache.groovy
@@ -154,7 +154,7 @@ class Cache<K, V> implements LogSupport, AdminStats {
         } else {
             _map.put(key, new CacheEntry(key, obj, loggerName))
         }
-        if (!useCluster) fireOnChange(this, oldEntry?.value, obj)
+        if (!useCluster) fireOnChange(key, oldEntry?.value, obj)
     }
 
 


### PR DESCRIPTION
Cache.put() was passing `this` (the Cache instance) as the key argument to
fireOnChange, while the cluster path (CacheEntryListener) correctly passed
the actual entry key. This caused CacheEntryChanged.key to have the wrong
type on single-instance or replicate-disabled deployments.