### PR TITLE
Expose whether a preference is explicitly set; support real unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 41.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Preference client config now includes a per-pref `isSet` flag, and a new `xh/unsetPrefs` endpoint
+  clears a user's explicit value - both additive for older hoist-react clients.
+
 ## 40.2.0 - 2026-07-10
 
 ### ⚙️ Technical

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -24,7 +24,7 @@ application settings, while preferences are per-user.
 | `PrefDiffService` | `grails-app/services/io/xh/hoist/pref/` | Cross-environment preference synchronization |
 | `PreferenceSpec` | `src/main/groovy/io/xh/hoist/pref/` | Typed specification for required preference definitions |
 | `PreferenceAdminController` | `grails-app/controllers/io/xh/hoist/admin/` | Admin Console CRUD endpoints for preference definitions |
-| `XhController` | `grails-app/controllers/io/xh/hoist/impl/` | Client-facing `getPrefs` / `setPrefs` endpoints |
+| `XhController` | `grails-app/controllers/io/xh/hoist/impl/` | Client-facing `getPrefs` / `setPrefs` / `unsetPrefs` endpoints |
 
 ## Key Classes
 
@@ -143,18 +143,22 @@ Returns all preferences for the current user in a structure consumed by hoist-re
   "theme": {
     "type": "string",
     "value": "dark",
-    "defaultValue": "light"
+    "defaultValue": "light",
+    "isSet": true
   },
   "defaultPageSize": {
     "type": "int",
     "value": 25,
-    "defaultValue": 25
+    "defaultValue": 25,
+    "isSet": false
   }
 }
 ```
 
 The `value` field contains the user's custom value if set, otherwise the default. JSON values are
-parsed to objects.
+parsed to objects. The `isSet` flag reports whether a `UserPreference` record exists for the user
+(the same distinction as `isUnset`, inverted) — letting the client tell an explicitly-set value
+apart from a fallback to the default, even when the two happen to be equal.
 
 #### `ensureRequiredPrefsCreated(requiredPrefs)`
 
@@ -261,7 +265,9 @@ XH.prefService.set('theme', 'dark');  // persists to server
 ```
 
 The hoist-react `PrefService` manages the client-local state and syncs changes back to the server
-via `XhController` endpoints (`/xh/getPrefs` to load, `/xh/setPrefs` to persist).
+via `XhController` endpoints (`/xh/getPrefs` to load, `/xh/setPrefs` to persist, and `/xh/unsetPrefs`
+to clear a user's explicit value and revert to the default). The `/xh/unsetPrefs` endpoint accepts a
+JSON array of preference keys and delegates to `PrefService.unsetPreference()`.
 
 In practice, most client-side interaction with preferences happens indirectly through hoist-react's
 **persistence system**, which automatically saves and restores UI state — grid column layouts,

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -166,6 +166,17 @@ class XhController extends BaseController {
         renderJSON(preferences: ret)
     }
 
+    def unsetPrefs() {
+        ensureClientUsernameMatchesSession()
+
+        def keys = parseRequestJSONArray().collect { it.toString() }
+        keys.each { prefService.unsetPreference(it) }
+
+        def ret = prefService.getLimitedClientConfig(keys)
+
+        renderJSON(preferences: ret)
+    }
+
     def clearUserState() {
         ensureClientUsernameMatchesSession()
         Preference.withNewTransaction {

--- a/grails-app/services/io/xh/hoist/pref/PrefService.groovy
+++ b/grails-app/services/io/xh/hoist/pref/PrefService.groovy
@@ -259,7 +259,6 @@ class PrefService extends BaseService {
             type: defaultPref.type,
             value: getUserPreference(defaultPref, userPref),
             defaultValue: defaultPref.externalDefaultValue(jsonAsObject: true),
-            // True if the user has an explicit value on file, vs. falling back to the pref default.
             isSet: userPref != null
         ]
     }

--- a/grails-app/services/io/xh/hoist/pref/PrefService.groovy
+++ b/grails-app/services/io/xh/hoist/pref/PrefService.groovy
@@ -258,7 +258,9 @@ class PrefService extends BaseService {
         return [
             type: defaultPref.type,
             value: getUserPreference(defaultPref, userPref),
-            defaultValue: defaultPref.externalDefaultValue(jsonAsObject: true)
+            defaultValue: defaultPref.externalDefaultValue(jsonAsObject: true),
+            // True if the user has an explicit value on file, vs. falling back to the pref default.
+            isSet: userPref != null
         ]
     }
 }


### PR DESCRIPTION
Adds server support for a client application to reliably distinguish a preference value that a user has **explicitly set** from one that is falling back to the **database default** - two distinct states that were previously collapsed in the client payload.

### Changes
- `PrefService.getClientConfig()` now emits a per-pref `isSet` flag (`userPref != null`), reported alongside `value`/`defaultValue`. No extra queries - `getClientConfig` already loads all user prefs.
- New `xh/unsetPrefs` endpoint (backed by the existing `PrefService.unsetPreference()`), accepting a JSON array of keys, so the client can clear a user's explicit value and revert to the default rather than persisting the default as an explicit value.

### Backward compatibility
Both additions are purely additive. Older hoist-react clients ignore the new flag and never call the new endpoint, so this can ship without a coordinated breaking release - an app can take newer hoist-core against an older hoist-react and continue to work unchanged.

Paired client PR: xh/hoist-react#4491