### PR TITLE
Add `BaseController.renderNdjson()` for streamed NDJSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎁 New Features
 
-* New `BaseController.renderNdJson()` streams an `Iterable` or `Iterator` to the client as
+* New `BaseController.renderNdjson()` streams an `Iterable` or `Iterator` to the client as
   newline-delimited JSON (NDJSON) — suitable for very large datasets that should not be
   materialized in memory as a single JSON string. Pairs with `XH.fetchNdjson()` in hoist-react.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 41.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* New `BaseController.renderNdJson()` streams an `Iterable` or `Iterator` to the client as
+  newline-delimited JSON (NDJSON) — suitable for very large datasets that should not be
+  materialized in memory as a single JSON string. Pairs with `XH.fetchNdjson()` in hoist-react.
+
+### ⚙️ Technical
+
+* `ExceptionHandler` no longer attempts to render an error to an already-committed response,
+  avoiding corrupted output and duplicate log entries when a streamed response fails mid-write.
+
 ## 40.3.0 - 2026-07-16
 
 ### 🎁 New Features

--- a/grails-app/controllers/io/xh/hoist/BaseController.groovy
+++ b/grails-app/controllers/io/xh/hoist/BaseController.groovy
@@ -9,6 +9,8 @@ package io.xh.hoist
 
 import grails.async.Promise
 import groovy.transform.CompileStatic
+import groovy.transform.NamedParam
+import groovy.transform.NamedVariant
 import io.xh.hoist.cluster.ClusterService
 import io.xh.hoist.cluster.ClusterResult
 import io.xh.hoist.json.JSONParser
@@ -24,6 +26,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import static grails.async.web.WebPromises.task
+import static java.nio.charset.StandardCharsets.UTF_8
 import static io.xh.hoist.HoistFilter.REQUEST_SPAN_ATTR
 import static org.apache.hc.core5.http.HttpStatus.SC_NO_CONTENT
 import static org.apache.hc.core5.http.HttpStatus.SC_OK
@@ -48,16 +51,70 @@ abstract class BaseController implements LogSupport, IdentitySupport {
     }
 
     /**
+     * Render a collection of objects as newline-delimited JSON (NDJSON), streaming each element
+     * to the client as it is serialized.
+     *
+     * Favor over {@link #renderJSON} for large row-oriented datasets — elements are written
+     * incrementally, so neither the full JSON string nor (for lazy sources) the full dataset is
+     * held in memory, and clients can parse rows as they arrive.
+     *
+     * The response is flushed (and committed) after the first element, so earlier failures still
+     * render a clean error response. A mid-stream failure cannot alter the committed status —
+     * instead the stream is terminated with a deliberately non-JSON line, so consumers fail
+     * parsing rather than mistaking the truncated (but otherwise well-formed) stream for a
+     * complete result. Successful streams are standard NDJSON, with every line
+     * newline-terminated and no end delimiter.
+     *
+     * @param source - an Iterable or Iterator of elements to serialize, one per line.
+     * @param contentType - defaults to 'text/plain', which (unlike 'application/x-ndjson') is on
+     *      default gzip/compressible MIME lists. Override if your deployment compresses NDJSON.
+     */
+    @NamedVariant
+    protected void renderNdJson(Object source, @NamedParam String contentType = null) {
+        Iterator<?> rows = source instanceof Iterator ? source : (source as Iterable).iterator()
+
+        response.contentType = contentType ?: 'text/plain'
+        response.characterEncoding = 'UTF-8'
+
+        BufferedOutputStream out = null
+        try {
+            while (rows.hasNext()) {
+                byte[] row = serializeNdJsonRow(rows.next())
+                boolean first = !out
+                if (first) {
+                    // Acquire the output stream lazily - first-element failures (bad source,
+                    // failing lazy query) can then still render a clean error response.
+                    out = new BufferedOutputStream(response.outputStream, ND_JSON_BUFFER_SIZE)
+                }
+                out.write(row)
+                if (first) out.flush()
+            }
+            out ? out.flush() : response.flushBuffer()
+        } catch (Throwable t) {
+            // Truncation falls at a line boundary and would otherwise read as a complete
+            // stream. Guarded so a failed write cannot mask the original exception.
+            if (response.committed) {
+                try {
+                    out.write(ND_JSON_POISON.getBytes(UTF_8))
+                    out.flush()
+                } catch (Throwable ignored) {}
+            }
+            throw t
+        }
+    }
+
+    /**
      * Parse JSON submitted in the body of the request.
      *
      * Favor this method over the direct use of grails' request.getJSON() in order
      * to utilize the customizable jackson-based parsing provided by Hoist.
      *
-     * @param  options.safeEncode, boolean.  True to run input through OWASP encoder before parsing.
+     * @param safeEncode - true to run input through OWASP encoder before parsing.
      */
-    protected Map parseRequestJSON(Map options = [:]) {
-        options.safeEncode ?
-            JSONParser.parseObject(safeEncode(request.inputStream.text)) :
+    @NamedVariant
+    protected Map parseRequestJSON(@NamedParam boolean safeEncode = false) {
+        safeEncode ?
+            JSONParser.parseObject(this.safeEncode(request.inputStream.text)) :
             JSONParser.parseObject(request.inputStream)
     }
 
@@ -67,11 +124,12 @@ abstract class BaseController implements LogSupport, IdentitySupport {
      * Favor this method over the direct use of grails' request.getJSON() in order
      * to utilize the customizable jackson-based parsing provided by Hoist.
      *
-     * @param  options.safeEncode, boolean.  True to run input through OWASP encoder before parsing.
+     * @param safeEncode - true to run input through OWASP encoder before parsing.
      */
-    protected List parseRequestJSONArray(Map options = [:]) {
-        options.safeEncode ?
-            JSONParser.parseArray(safeEncode(request.inputStream.text)) :
+    @NamedVariant
+    protected List parseRequestJSONArray(@NamedParam boolean safeEncode = false) {
+        safeEncode ?
+            JSONParser.parseArray(this.safeEncode(request.inputStream.text)) :
             JSONParser.parseArray(request.inputStream)
     }
 
@@ -146,6 +204,25 @@ abstract class BaseController implements LogSupport, IdentitySupport {
     //-------------------
     // Implementation
     //-------------------
+    /**
+     * Batches rows into large writes to amortize per-call overhead of the servlet output stream.
+     * 4x Tomcat's default 8KB response buffer and equal to the 32KB deflate window — larger
+     * values gain no throughput and only delay delivery to the client.
+     */
+    private static final int ND_JSON_BUFFER_SIZE = 32 * 1024
+
+    /**
+     * Deliberately non-JSON line written by {@link #renderNdJson} when a stream fails after the
+     * response has committed. Guarantees consumers see a parse failure rather than a truncated
+     * stream that reads as complete. Never present in a successful response, which remains
+     * standard NDJSON. No trailing newline — an incomplete final line reinforces the signal.
+     */
+    private static final String ND_JSON_POISON = '//xh-ndjson-stream-error'
+
+    private static byte[] serializeNdJsonRow(Object row) {
+        (JSONSerializer.serialize(row) + '\n').getBytes(UTF_8)
+    }
+
     void handleException(Exception ex) {
         handleUncaughtInternal(ex)
     }

--- a/grails-app/controllers/io/xh/hoist/BaseController.groovy
+++ b/grails-app/controllers/io/xh/hoist/BaseController.groovy
@@ -70,7 +70,7 @@ abstract class BaseController implements LogSupport, IdentitySupport {
      *      default gzip/compressible MIME lists. Override if your deployment compresses NDJSON.
      */
     @NamedVariant
-    protected void renderNdJson(Object source, @NamedParam String contentType = null) {
+    protected void renderNdjson(Object source, @NamedParam String contentType = null) {
         Iterator<?> rows = source instanceof Iterator ? source : (source as Iterable).iterator()
 
         response.contentType = contentType ?: 'text/plain'
@@ -79,12 +79,12 @@ abstract class BaseController implements LogSupport, IdentitySupport {
         BufferedOutputStream out = null
         try {
             while (rows.hasNext()) {
-                byte[] row = serializeNdJsonRow(rows.next())
+                byte[] row = serializeNdjsonRow(rows.next())
                 boolean first = !out
                 if (first) {
                     // Acquire the output stream lazily - first-element failures (bad source,
                     // failing lazy query) can then still render a clean error response.
-                    out = new BufferedOutputStream(response.outputStream, ND_JSON_BUFFER_SIZE)
+                    out = new BufferedOutputStream(response.outputStream, NDJSON_BUFFER_SIZE)
                 }
                 out.write(row)
                 if (first) out.flush()
@@ -95,7 +95,7 @@ abstract class BaseController implements LogSupport, IdentitySupport {
             // stream. Guarded so a failed write cannot mask the original exception.
             if (response.committed) {
                 try {
-                    out.write(ND_JSON_POISON.getBytes(UTF_8))
+                    out.write(NDJSON_POISON.getBytes(UTF_8))
                     out.flush()
                 } catch (Throwable ignored) {}
             }
@@ -209,17 +209,17 @@ abstract class BaseController implements LogSupport, IdentitySupport {
      * 4x Tomcat's default 8KB response buffer and equal to the 32KB deflate window — larger
      * values gain no throughput and only delay delivery to the client.
      */
-    private static final int ND_JSON_BUFFER_SIZE = 32 * 1024
+    private static final int NDJSON_BUFFER_SIZE = 32 * 1024
 
     /**
-     * Deliberately non-JSON line written by {@link #renderNdJson} when a stream fails after the
+     * Deliberately non-JSON line written by {@link #renderNdjson} when a stream fails after the
      * response has committed. Guarantees consumers see a parse failure rather than a truncated
      * stream that reads as complete. Never present in a successful response, which remains
      * standard NDJSON. No trailing newline — an incomplete final line reinforces the signal.
      */
-    private static final String ND_JSON_POISON = '//xh-ndjson-stream-error'
+    private static final String NDJSON_POISON = '//xh-ndjson-stream-error'
 
-    private static byte[] serializeNdJsonRow(Object row) {
+    private static byte[] serializeNdjsonRow(Object row) {
         (JSONSerializer.serialize(row) + '\n').getBytes(UTF_8)
     }
 

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -113,7 +113,7 @@ class XhController extends BaseController {
     //------------------------
     def track() {
         ensureClientUsernameMatchesSession()
-        def payload = parseRequestJSON([safeEncode: true]),
+        def payload = parseRequestJSON(safeEncode: true),
             entries =  payload.entries as List
         trackService.trackAll(entries)
         renderSuccess()

--- a/src/main/groovy/io/xh/hoist/exception/ExceptionHandler.groovy
+++ b/src/main/groovy/io/xh/hoist/exception/ExceptionHandler.groovy
@@ -62,7 +62,8 @@ class ExceptionHandler {
             }
         }
 
-        if (renderTo) {
+        // Skip if committed - status/headers already sent, rendering would only corrupt the body.
+        if (renderTo && !renderTo.committed) {
             renderTo.setStatus(getHttpStatus(exception))
             renderTo.setContentType('application/json')
             renderTo.writer.write(JSONSerializer.serialize(exception))


### PR DESCRIPTION
- New `BaseController.renderNdjson()` streams an `Iterable`/`Iterator` to the client as NDJSON via Hoist's `JSONSerializer`, without materializing the full payload in memory. Pairs with `XH.fetchNdjson()` in hoist-react (unreleased).
- Flushes after the first element; setup failures still render a clean error response. A stream failing post-commit is terminated with a non-JSON line, so consumers detect truncation as a parse failure rather than loading a partial dataset as complete.
- `ExceptionHandler` now skips rendering to an already-committed response, avoiding corrupted output and duplicate log entries.
- Converted `parseRequestJSON`/`parseRequestJSONArray` to `@NamedVariant` — backward compatible.
