### PR TITLE
Add `SpanRef.setErrorStatus()` for failures without a Throwable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@
 * New `BaseController.renderNdjson()` streams an `Iterable` or `Iterator` to the client as
   newline-delimited JSON (NDJSON) — suitable for very large datasets that should not be
   materialized in memory as a single JSON string. Pairs with `XH.fetchNdjson()` in hoist-react.
+* New `SpanRef.setErrorStatus()` marks a trace span as failed with an optional description, for
+  failures that are neither an exception nor an HTTP response. Avoids the need to synthesize a
+  throwable - and its fabricated stack trace - purely to flag a span.
 
 ### ⚙️ Technical
 
 * `ExceptionHandler` no longer attempts to render an error to an already-committed response,
   avoiding corrupted output and duplicate log entries when a streamed response fails mid-write.
+* `ClientSpanData` now carries the `statusDescription` sent by client-relayed spans through to the
+  exported span status, rather than discarding it. No behavioral change with current clients, which
+  send an equivalent `exception` event.
 
 ## 40.3.0 - 2026-07-16
 

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -118,7 +118,7 @@
             "mcpCategory": "package",
             "viewerCategory": "infrastructure",
             "description": "OpenTelemetry-based distributed tracing with OTLP export.",
-            "keywords": ["TraceService", "withSpan", "traceparent", "OTLP", "xhTraceConfig", "OpenTelemetry", "ClientTraceService", "ContextPropagatingPromiseFactory"]
+            "keywords": ["TraceService", "withSpan", "SpanRef", "setErrorStatus", "traceparent", "OTLP", "xhTraceConfig", "OpenTelemetry", "ClientTraceService", "ContextPropagatingPromiseFactory"]
         },
         {
             "id": "docs/websocket.md",

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -110,6 +110,56 @@ traceService.addExporter(
 
 ---
 
+## SpanRef
+
+**File:** `src/main/groovy/io/xh/hoist/telemetry/trace/SpanRef.groovy`
+
+A wrapper around an active OTel `Span` and its `Scope`, returned by `createSpan` and passed to the
+closures run by `withSpan` and `ObservedRun.run`. Use it to enrich a span in flight with tags, a
+revised name, or the outcome of the work.
+
+A shared no-op instance (`SpanRef.NOOP`) is passed when tracing is disabled, so closure bodies can
+call these methods unconditionally without null-checking.
+
+| Method | Description |
+|--------|-------------|
+| `setTag(key, value)` | Set a single attribute. Coerces `Integer`/`Long` → long, `Boolean` → boolean, `Double` → double, anything else via `toString()`. |
+| `setTags(map)` | Set multiple attributes, with the same coercion rules. |
+| `updateName(name)` | Revise the span's display name — useful once a generic operation resolves to something more specific. |
+| `setErrorStatus(description?)` | Mark ERROR with an optional description, no exception required. |
+| `recordException(t)` | Record an exception event. Leaves span status untouched. No-op for `RoutineException`. |
+| `recordExceptionAndErrorStatus(t)` | Record an exception event **and** mark ERROR, with a description derived from the throwable. No-op for `RoutineException`. |
+| `setHttpStatusAndErrorStatus(code)` | Set the `http.response.status_code` tag and mark ERROR per OTel HTTP conventions: CLIENT spans at ≥400, SERVER spans at ≥500. |
+| `close()` | Close the scope and end the span. Required for spans from `createSpan`; handled for you by `withSpan`. |
+
+### Flagging failures without an exception
+
+Not every failure arrives as a `Throwable` or an HTTP status — a validation rejection, a
+well-formed but unusable payload from a dependency, or a batch that completes with unrecoverable
+records are all real failures with nothing to catch. Use `setErrorStatus` for these:
+
+```groovy
+span(name: 'importOrders').run { SpanRef span ->
+    def result = orderImporter.run()
+    span.setTag('rejectedCount', result.rejected.size())
+    if (result.rejected) {
+        span.setErrorStatus("Rejected ${result.rejected.size()} of ${result.total} orders")
+    }
+    result
+}
+```
+
+Do **not** synthesize a throwable just to flag a span. Beyond the fabricated stack trace, Datadog's
+OTLP intake maps any exception event onto `error.*` tags, so an invented exception yields an
+invented `error.type` and `error.stack`.
+
+Note that `setErrorStatus` is unconditional — unlike the `recordException` methods, it does not skip
+`RoutineException` cases, since the caller is explicitly asking for the status. Also note that span
+status is last-call-wins, so a later `recordExceptionAndErrorStatus` on the same span will overwrite
+an earlier description.
+
+---
+
 ## ObservedRun
 
 **File:** `src/main/groovy/io/xh/hoist/telemetry/ObservedRun.groovy`

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -12,7 +12,7 @@ delegate to no-op implementations, so no null checks are needed in application c
 ### Key capabilities
 
 - **Central service** — `TraceService` manages the OpenTelemetry SDK lifecycle, exporter
-  pipeline, and provides span creation APIs (`withSpan` and `createSpan`).
+  pipeline, and provides the `withSpan` span creation API.
 - **Combined observability** — `ObservedRun` is a composable builder that wraps a closure with
   any combination of tracing, logging, and metrics. Typically started via `BaseService.span()`,
   with `BaseService.observe()` available for the rare case where no span is wanted.
@@ -117,9 +117,9 @@ traceService.addExporter(
 
 **File:** `src/main/groovy/io/xh/hoist/telemetry/trace/SpanRef.groovy`
 
-A wrapper around an active OTel `Span` and its `Scope`, returned by `createSpan` and passed to the
-closures run by `withSpan` and `ObservedRun.run`. Use it to enrich a span in flight with tags, a
-revised name, or the outcome of the work.
+A wrapper around an active OTel `Span` and its `Scope`, passed to the closures run by `withSpan` and
+`ObservedRun.run`. Use it to enrich a span in flight with tags, a revised name, or the outcome of
+the work.
 
 A shared no-op instance (`SpanRef.NOOP`) is passed when tracing is disabled, so closure bodies can
 call these methods unconditionally without null-checking.
@@ -133,7 +133,7 @@ call these methods unconditionally without null-checking.
 | `recordException(t)` | Record an exception event. Leaves span status untouched. No-op for `RoutineException`. |
 | `recordExceptionAndErrorStatus(t)` | Record an exception event **and** mark ERROR, with a description derived from the throwable. No-op for `RoutineException`. |
 | `setHttpStatusAndErrorStatus(code)` | Set the `http.response.status_code` tag and mark ERROR per OTel HTTP conventions: CLIENT spans at ≥400, SERVER spans at ≥500. |
-| `close()` | Close the scope and end the span. Required for spans from `createSpan`; handled for you by `withSpan`. |
+| `close()` | Close the scope and end the span. Handled for you by `withSpan` and `ObservedRun.run`. |
 
 ### Flagging failures without an exception
 

--- a/src/main/groovy/io/xh/hoist/telemetry/trace/ClientSpanData.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/trace/ClientSpanData.groovy
@@ -97,10 +97,11 @@ class ClientSpanData implements SpanData, ReadableSpan {
             )
         }
 
-        // Status
+        // Status -- per OTel spec, the description is only meaningful for ERROR and is ignored
+        // for ok/unset, so it is read on that branch alone.
         switch (span.status as String) {
             case 'ok':    _status = StatusData.ok(); break
-            case 'error': _status = StatusData.create(StatusCode.ERROR, ''); break
+            case 'error': _status = StatusData.create(StatusCode.ERROR, span.statusDescription as String ?: ''); break
             default:      _status = StatusData.unset()
         }
     }

--- a/src/main/groovy/io/xh/hoist/telemetry/trace/SpanRef.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/trace/SpanRef.groovy
@@ -70,13 +70,30 @@ class SpanRef implements Closeable {
     }
 
     /**
-     * Set the HTTP response status code and mark the span as ERROR when appropriate.
-     * SERVER spans use >= 500 (server fault), CLIENT spans use >= 400 (request failed).
+     * Mark the span status as ERROR, with an optional short description of the failure.
+     *
+     * For failures that are neither an exception nor an HTTP response — e.g. a validation
+     * rejection, a well-formed but unusable payload from a dependency, or a batch completing
+     * with unrecoverable records. Prefer {@link #recordExceptionAndErrorStatus} when an actual
+     * Throwable is in hand, and {@link #setHttpStatusAndErrorStatus} for HTTP outcomes —
+     * do not synthesize a Throwable purely to flag a span.
+     *
+     * Note this applies the status unconditionally — unlike the recordException methods, it
+     * does not skip {@link RoutineException} cases, as the caller is explicitly asking for it.
      */
-    void setHttpStatusAndErrorStatus(int statusCode) {
-        setTag('http.response.status_code', statusCode)
-        def errorThreshold = kind == SpanKind.CLIENT ? 400 : 500
-        if (statusCode >= errorThreshold) span.setStatus(StatusCode.ERROR)
+    void setErrorStatus(String description = null) {
+        if (description) {
+            span.setStatus(StatusCode.ERROR, description)
+        } else {
+            span.setStatus(StatusCode.ERROR)
+        }
+    }
+
+    /** Record an exception as an event on the span. Does not change span status.*/
+    void recordException(Throwable t) {
+        // Skip routine exceptions -- Datadog's OTLP intake maps any exception event onto error.* tags.
+        if (t instanceof RoutineException) return
+        span.recordException(t)
     }
 
     /**
@@ -90,11 +107,14 @@ class SpanRef implements Closeable {
         span.setStatus(StatusCode.ERROR, exceptionHandler.summaryTextForThrowable(t))
     }
 
-    /** Record an exception as an event on the span. Does not change span status.*/
-    void recordException(Throwable t) {
-        // Skip routine exceptions -- Datadog's OTLP intake maps any exception event onto error.* tags.
-        if (t instanceof RoutineException) return
-        span.recordException(t)
+    /**
+     * Set the HTTP response status code and mark the span as ERROR when appropriate.
+     * SERVER spans use >= 500 (server fault), CLIENT spans use >= 400 (request failed).
+     */
+    void setHttpStatusAndErrorStatus(int statusCode) {
+        setTag('http.response.status_code', statusCode)
+        def errorThreshold = kind == SpanKind.CLIENT ? 400 : 500
+        if (statusCode >= errorThreshold) span.setStatus(StatusCode.ERROR)
     }
 
     /** Close the scope and end the span. */

--- a/src/main/groovy/io/xh/hoist/telemetry/trace/SpanRef.groovy
+++ b/src/main/groovy/io/xh/hoist/telemetry/trace/SpanRef.groovy
@@ -16,17 +16,20 @@ import io.xh.hoist.exception.RoutineException
 import static io.xh.hoist.util.Utils.exceptionHandler
 
 /**
- * An active span and its associated scope, returned by {@link TraceService#createSpan}.
- *
- * The caller is responsible for closing this when done — typically in a finally block:
+ * An active span and its associated scope, passed to closures run by
+ * {@link TraceService#withSpan} and {@link io.xh.hoist.telemetry.ObservedRun#run}. Use it to enrich
+ * a span in flight with tags, a revised name, or the outcome of the work:
  * <pre>
- * def spanRef = traceService.createSpan(name: 'myOp', kind: SpanKind.SERVER)
- * try {
- *     // ... do work, span is current context ...
- * } finally {
- *     spanRef?.close()
+ * traceService.withSpan(name: 'fetchData', kind: SpanKind.CLIENT) { SpanRef span ->
+ *     def result = doWork()
+ *     span.setTag('resultCount', result.size())
+ *     result
  * }
  * </pre>
+ *
+ * Those entry points close the span for the caller. Spans with a manually managed lifecycle come
+ * from {@code TraceService.createSpan}, which is framework-internal — that caller is responsible
+ * for calling {@link #close}, typically in a finally block.
  */
 @CompileStatic
 class SpanRef implements Closeable {


### PR DESCRIPTION
Closes #578.

Every existing path to ERROR status on a span required either a `Throwable` or an HTTP status code, so a failure that is neither — a validation rejection, a well-formed but unusable payload, a batch completing with unrecoverable records — could only be flagged by synthesizing an exception. That emits a fabricated stack trace and, per the Datadog note already on `recordException`, fills `error.*` tags with fiction.

### Changes

* **`SpanRef.setErrorStatus(String description = null)`** — marks the span ERROR with an optional description. A thin wrapper over `Span.setStatus`; the OTel spec defines the status description as meaningful only with ERROR, so the signature maps 1:1 onto the primitive. Applied unconditionally — unlike the `recordException` methods it does not filter `RoutineException`, since the caller is explicitly asking for it.
* **Reordered the four error methods** primitive → composite → specialized (`setErrorStatus`, `recordException`, `recordExceptionAndErrorStatus`, `setHttpStatusAndErrorStatus`), so each is defined in terms of ones already introduced.
* **`ClientSpanData` now carries `statusDescription`** through to the exported span status instead of hardcoding empty. No behavioral change with current clients, which only populate the field alongside an equivalent `exception` event — this is preparatory for a public client-side error-status API.
* **Docs** — `tracing.md` gained the `SpanRef` section it never had, plus guidance on flagging non-exception failures. Also stops presenting `createSpan` as an app-facing entry point in `SpanRef`'s Groovydoc, following the accuracy pass already on develop.

### For reviewers

* **Naming.** `setErrorStatus` follows the server's `...AndErrorStatus` convention rather than hoist-react's `setError`. The two platforms already diverge here (`setHttpStatusAndErrorStatus` vs `setHttpStatus`), so internal consistency won — easy to flip if preferred.
* **Unverified.** Whether Datadog's OTLP intake surfaces an ERROR status description with no accompanying exception event has not been checked against a real backend. If it doesn't, this should also emit an event or tag carrying the reason — which ties into #560. The signature accommodates that without a breaking change.
* The `ClientSpanData` fix is its own commit and can be dropped independently if you'd rather it ride with the hoist-react work.

### Follow-up

hoist-react has the mirror gap: `core/Span.ts` already models `status`/`statusDescription` and has a `setError(description?)`, but it's private, so app code can't reach it either. That change is what makes the `ClientSpanData` fix here load-bearing.
