### PR TITLE
Make view group rename an explicit, scoped operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,26 @@
   newline-delimited JSON (NDJSON) — suitable for very large datasets that should not be
   materialized in memory as a single JSON string. Pairs with `XH.fetchNdjson()` in hoist-react.
 
+* Provides support for the nested view groups and bulk view editing in the hoist-react v87
+  `ViewManager` Manage dialog, which requires this release. Backward compatible for earlier
+  hoist-react clients. View groups are now slash-delimited paths supporting unlimited nesting
+  (e.g. `Reports/Sales/Monthly`), with new server-side support as follows:
+    * `ViewService.renameGroup` and a matching `xhView/renameGroup` endpoint rename or re-parent a
+      group along with its entire subtree, cascading to every view within it. The scope of the
+      rename is explicit - either the global views, or those owned by the requesting user.
+    * `JsonBlobService.renameGroup` provides the underlying support, rewriting `meta.group` across
+      all blobs of a given type within a single owner namespace in one transaction.
+    * `ViewService.bulkUpdateInfo` and a matching `xhView/bulkUpdateInfo` endpoint apply the same
+      metadata updates (e.g. visibility changes) to multiple views in a single call.
+
 ### ⚙️ Technical
 
 * `ExceptionHandler` no longer attempts to render an error to an already-committed response,
   avoiding corrupted output and duplicate log entries when a streamed response fails mid-write.
+
+* Fixed `ViewService.updateInfo` and `create` failing when passed `isPinned`. Both took the view
+  type from the caller-supplied data (which the hoist-react `ViewManager` does not send on update)
+  rather than from the view itself.
 
 ## 40.3.0 - 2026-07-16
 
@@ -20,14 +36,6 @@
 * Preference client config now includes a per-pref `isSet` flag, and a new `xh/unsetPrefs` endpoint
   clears a user's explicit value.  Provides support for hoist-react v86.4.0, but
   backward compatible for earlier hoist-react clients.
-
-* Added support for unlimited depth view groups in `ViewService` / `JsonBlobService`. Groups are
-  now slash-delimited paths (e.g. `Reports/Sales/Monthly`), and the `updateInfo` Map accepts a new
-  `groupRename: [from:, to:]` option to cascade a group rename or re-parenting across all other
-  views under the renamed path. Added `ViewService.bulkUpdateInfo` and a matching
-  `xhView/bulkUpdateInfo` endpoint to apply the same metadata updates (e.g. visibility changes)
-  to multiple views in a single call. Pairs with the nested group tree and bulk visibility
-  editing UI in the hoist-react v87 `ViewManager` Manage dialog.
 
 ## 40.2.0 - 2026-07-10
 

--- a/grails-app/controllers/io/xh/hoist/impl/XhViewController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhViewController.groovy
@@ -57,4 +57,17 @@ class XhViewController extends BaseController {
     def updateValue(String token) {
         renderJSON(viewService.updateValue(token, parseRequestJSON()))
     }
+
+    //------------------
+    // Group management
+    //------------------
+    def renameGroup(String type) {
+        Map data = parseRequestJSON()
+        renderJSON(viewService.renameGroup(
+            type,
+            data.from as String,
+            data.to as String,
+            data.isGlobal as boolean
+        ))
+    }
 }

--- a/grails-app/services/io/xh/hoist/jsonblob/JsonBlobService.groovy
+++ b/grails-app/services/io/xh/hoist/jsonblob/JsonBlobService.groovy
@@ -16,6 +16,20 @@ import static io.xh.hoist.json.JSONParser.parseObject
 import static io.xh.hoist.json.JSONSerializer.serialize
 import static java.lang.System.currentTimeMillis
 
+/**
+ * Service to persist and retrieve arbitrary JSON data as `JsonBlob` domain objects - suitable for
+ * application state that does not warrant its own domain class. Exposed to hoist-react's
+ * `XH.jsonBlobService` via `XhController`, and used within Hoist by services such as `ViewService`
+ * (ViewManager views) and `AlertBannerService`.
+ *
+ * Blobs are identified by a generated `token` and grouped by an application-defined `type`, with a
+ * `name` that must be unique for a given type and owner. Each holds a JSON `value`, plus optional
+ * `meta` for application-specific metadata. `archive` soft-deletes by setting `archivedDate`, and
+ * lookups here return active blobs only.
+ *
+ * Access is granted per blob: to its `owner`, or to all users when its `acl` is set to the wildcard
+ * `*`. A null owner indicates a global blob, belonging to no single user.
+ */
 class JsonBlobService extends BaseService implements DataBinder {
 
     @ReadOnly
@@ -53,15 +67,76 @@ class JsonBlobService extends BaseService implements DataBinder {
         )
     }
 
-    /**
-     * Update an active blob. Note `groupRename` is a reserved key within `data` - an optional
-     * `[from:, to:]` map that is stripped from the bound update and instead cascades a group path
-     * rename across other blobs of the same type and owner (see `cascadeGroupRename`).
-     */
+    /** Update an active blob. */
     @Transactional
     JsonBlob update(String token, Map data, String username = username) {
-        def blob = get(token, username)
+        JsonBlob blob = get(token, username)
         return updateInternal(blob, data, username)
+    }
+
+    /**
+     * Rename a group path across all active blobs of a given type within a single owner namespace,
+     * rewriting `meta.group` on every blob whose group equals or falls under the `from` path.
+     *
+     * Group paths support nesting via forward-slash delimiters (e.g. for ViewManager), so this
+     * both renames a group in place and re-parents it along with its subtree - renaming "A/B" to
+     * "A/C" rewrites "A/B" -> "A/C" and "A/B/x" -> "A/C/x". All matching blobs are rewritten
+     * within a single transaction.
+     *
+     * @param type - blob type within which to rename.
+     * @param ownerName - owner whose blobs are to be renamed, or null for the global (null-owner)
+     *      namespace. Groups are namespaced per owner, so the same path can exist independently
+     *      for each owner and within the global namespace.
+     * @param from - group path to rename. Required, and matched both exactly and as the parent of
+     *      any paths nested beneath it.
+     * @param to - replacement group path. Required.
+     * @param username - user on whose behalf the rename is made. Determines which blobs are
+     *      eligible per their ACL, and is recorded as `lastUpdatedBy` on each blob rewritten.
+     * @return count of blobs whose group path was rewritten.
+     */
+    @Transactional
+    int renameGroup(String type, String ownerName, String from, String to, String username = username) {
+        from = from?.trim()
+        to = to?.trim()
+
+        if (!from || !to) {
+            throw new IllegalArgumentException("Group rename requires both 'from' and 'to' group paths")
+        }
+
+        List<JsonBlob> candidates = JsonBlob.createCriteria().list {
+            eq('type', type)
+            eq('archivedDate', 0L)
+            ownerName != null ? eq('owner', ownerName) : isNull('owner')
+        } as List<JsonBlob>
+
+        int count = 0
+        candidates.each { JsonBlob blob ->
+            if (!passesAcl(blob, username)) return
+
+            Map meta
+            try {
+                meta = parseObject(blob.meta)
+            } catch (Exception e) {
+                logWarn('Skipping blob with unparsable meta in group rename', [token: blob.token], e)
+                return
+            }
+
+            if (!(meta?.group instanceof String)) return
+
+            String group = meta.group
+            if (group != from && !group.startsWith(from + '/')) return
+
+            String renamed = to + group.substring(from.length())
+            if (renamed == group) return
+
+            meta.group = renamed
+            blob.meta = serialize(meta)
+            blob.lastUpdatedBy = username
+            blob.save()
+            count++
+        }
+        logInfo('Renamed group', [type: type, from: from, to: to, updated: count])
+        return count
     }
 
     @Transactional
@@ -96,67 +171,14 @@ class JsonBlobService extends BaseService implements DataBinder {
     //-------------------------
     private JsonBlob updateInternal(JsonBlob blob, Map data, String username) {
         if (data) {
-            Map groupRename = data.groupRename as Map
-            String prevOwner = blob.owner
-
-            data = data.findAll { it.key != 'groupRename' }
             data = [*: data, lastUpdatedBy: username]
             if (data.containsKey('value')) data.value = serialize(data.value)
             if (data.containsKey('meta')) data.meta = serialize(data.meta)
 
             bindData(blob, data)
             blob.save()
-
-            if (groupRename) {
-                cascadeGroupRename(blob, prevOwner, groupRename.from as String, groupRename.to as String, username)
-            }
         }
         return blob
-    }
-
-    /**
-     * Rewrite `meta.group` on all other active blobs of the same type and owner whose group
-     * equals or falls under a renamed group path. Group paths support nesting via forward-slash
-     * delimiters (e.g. for ViewManager) - renaming "A/B" to "A/C" rewrites "A/B" -> "A/C" and
-     * "A/B/x" -> "A/C/x" on all matching blobs, within the caller's transaction.
-     *
-     * Scoped to the owner the source blob had before the triggering update, so groups remain
-     * namespaced per owner (or per the global, null-owner namespace) even if the update also
-     * changed the blob's owner. Rewrites only blobs the acting user could update individually
-     * per their ACL.
-     */
-    private void cascadeGroupRename(JsonBlob source, String owner, String from, String to, String username) {
-        if (!from?.trim() || !to?.trim() || from == to) return
-
-        def candidates = JsonBlob.createCriteria().list {
-            eq('type', source.type)
-            eq('archivedDate', 0L)
-            owner != null ? eq('owner', owner) : isNull('owner')
-        } as List<JsonBlob>
-
-        def count = 0
-        candidates.each { blob ->
-            if (blob.token == source.token) return
-            // Rewrite only blobs the caller could update individually - the source blob's ACL
-            // must not grant transitive write access to other blobs in the owner's namespace.
-            if (!passesAcl(blob, username)) return
-            Map meta
-            try {
-                meta = parseObject(blob.meta)
-            } catch (Exception ignored) {
-                return
-            }
-            def group = meta?.group
-            if (!(group instanceof String)) return
-            if (group == from || group.startsWith(from + '/')) {
-                meta.group = to + group.substring(from.length())
-                blob.meta = serialize(meta)
-                blob.lastUpdatedBy = username
-                blob.save()
-                count++
-            }
-        }
-        logDebug('Cascaded group rename', [type: source.type, from: from, to: to, updated: count])
     }
 
 

--- a/grails-app/services/io/xh/hoist/view/ViewService.groovy
+++ b/grails-app/services/io/xh/hoist/view/ViewService.groovy
@@ -9,9 +9,12 @@ package io.xh.hoist.view
 
 import groovy.transform.CompileStatic
 import io.xh.hoist.BaseService
+import io.xh.hoist.exception.ExceptionHandler
+import io.xh.hoist.exception.RoutineRuntimeException
 import io.xh.hoist.jsonblob.JsonBlob
 import io.xh.hoist.jsonblob.JsonBlobService
 import io.xh.hoist.track.TrackService
+import io.xh.hoist.util.Utils
 
 import static io.xh.hoist.json.JSONParser.parseObject
 
@@ -115,12 +118,7 @@ class ViewService extends BaseService {
             ], username)
 
         if (data.containsKey('isPinned')) {
-            updateState(
-                data.type as String,
-                'default',
-                [userPinned: [(ret.token): data.isPinned]],
-                username
-            )
+            updatePinned(ret.type, [ret.token], data.isPinned, username)
         }
 
         trackChange('Created View', ret)
@@ -131,49 +129,62 @@ class ViewService extends BaseService {
      * Update a view's metadata.
      *
      * Supported keys in `data` include `name`, `description`, `group`, `isGlobal`, `isShared` and
-     * `isPinned`, plus an optional `groupRename: [from:, to:]` map. Groups are slash-delimited
-     * paths supporting unlimited nesting (e.g. "Reports/Sales/Monthly"). When `groupRename` is
-     * provided, all other active views of the same type and owner whose group equals or falls
-     * under the `from` path have that prefix of their group path rewritten to `to` within the
-     * same transaction - use when the user has renamed or re-parented a group itself, as opposed
-     * to moving this single view into a different group.
+     * `isPinned`. Groups are slash-delimited paths supporting unlimited nesting (e.g.
+     * "Reports/Sales/Monthly"); this moves the single view in question into the given group. See
+     * {@link #renameGroup} to rename or re-parent a group across all of the views within it.
      */
     Map updateInfo(String token, Map data, String username = username) {
-        def ret = doUpdateInfo(token, data, username)
+        JsonBlob ret = doUpdateInfo(token, data, username)
+
+        if (data.containsKey('isPinned')) {
+            updatePinned(ret.type, [ret.token], data.isPinned, username)
+        }
 
         trackChange('Updated View Info', ret)
-        if (data.groupRename) {
-            def rename = data.groupRename as Map
-            trackChange('Renamed View Group', [type: ret.type, from: rename.from, to: rename.to])
-        }
         ret.formatForClient(true)
     }
 
     /**
      * Bulk update view metadata - applies the same updates to each of the given views.
-     * Supports the same keys in `data` as {@link #updateInfo}, except `groupRename`, which is
-     * ignored here - its cross-view cascade is intended for single-view updates only. Updates
-     * are applied best-effort: failures on individual views are logged and reported via a
-     * single exception thrown after all views have been attempted.
+     * Supports the same keys in `data` as {@link #updateInfo}. Any `isPinned` change is applied to
+     * all successfully updated views, in one state update per view type.
+     *
+     * Updates are applied best-effort: failures on individual views are logged and reported via
+     * a single exception, thrown after all views have been attempted and reporting the token and
+     * reason for each view that could not be updated.
      */
     void bulkUpdateInfo(List<String> tokens, Map data, String username = username) {
-        data = data.findAll { it.key != 'groupRename' }
-        List<Exception> failures = []
-        tokens.each {
+        Map<String, Exception> failures = [:]
+        List<JsonBlob> updated = []
+        tokens.each { String token ->
             try {
-                doUpdateInfo(it, data, username)
+                updated << doUpdateInfo(token, data, username)
             } catch (Exception e) {
-                failures << e
-                logError('Failed to update View info', [token: it], e)
+                failures[token] = e
+                logError('Failed to update View info', [token: token], e)
             }
         }
-        def successCount = tokens.size() - failures.size()
-        if (successCount) {
-            trackChange('Bulk Updated View Info', [count: successCount])
+
+        if (updated) {
+            // Pinned state is stored per view type, so update each type's state blob just once.
+            if (data.containsKey('isPinned')) {
+                updated.groupBy { it.type }.each { String type, List<JsonBlob> blobs ->
+                    updatePinned(type, blobs*.token, data.isPinned, username)
+                }
+            }
+            trackChange('Bulk Updated View Info', [count: updated.size()])
         }
 
         if (failures) {
-            throw new RuntimeException("Failed to update ${failures.size()} view(s)", failures.first())
+            String detail = failures.collect { token, e -> "$token: ${e.message}" }.join('; '),
+                msg = "Failed to update ${failures.size()} of ${tokens.size()} view(s) - $detail"
+
+            // Preserve routine (expected) failures as such, so a name collision or access error
+            // does not get reported to the client as a 500 and logged as a server error.
+            ExceptionHandler exceptionHandler = Utils.exceptionHandler
+            throw failures.values().every { exceptionHandler.isRoutine(it) } ?
+                new RoutineRuntimeException(msg) :
+                new RuntimeException(msg, failures.values().first())
         }
     }
 
@@ -208,12 +219,49 @@ class ViewService extends BaseService {
     }
 
 
+    //------------------
+    // Group management
+    //------------------
+    /**
+     * Rename a view group, cascading to every view at or nested under the renamed path.
+     *
+     * Groups are slash-delimited paths, so this both renames a group in place and re-parents it
+     * along with its entire subtree - e.g. renaming "Reports/Sales" to "Archive/Sales" also takes
+     * "Reports/Sales/Monthly" with it.
+     *
+     * The scope of the rename is explicit and limited to a single group namespace: either the
+     * global views, or the views owned by the requesting user (including any they have shared with
+     * others). Groups are namespaced per owner, so the same path can exist independently in each
+     * and renaming one never affects the other.
+     *
+     * @return count of views whose group path was rewritten, as `count`.
+     */
+    Map renameGroup(String type, String from, String to, boolean isGlobal, String username = username) {
+        int count = jsonBlobService.renameGroup(type, isGlobal ? null : username, from, to, username)
+
+        trackChange('Renamed View Group', [
+            type    : type,
+            from    : from,
+            to      : to,
+            isGlobal: isGlobal,
+            count   : count
+        ])
+        return [count: count]
+    }
+
+
     //--------------------
     // Implementation
     //---------------------
+    /**
+     * Apply metadata updates to a single view, returning the updated blob.
+     *
+     * Note that any `isPinned` change is *not* applied here - that state lives in a per-type
+     * sidecar blob and is updated once per call by `updateInfo` / `bulkUpdateInfo`.
+     */
     private JsonBlob doUpdateInfo(String token, Map data, String username) {
-        def existing = jsonBlobService.get(token, username),
-            meta = parseObject(existing.meta) ?: [:],
+        JsonBlob existing = jsonBlobService.get(token, username)
+        Map meta = parseObject(existing.meta) ?: [:],
             core = [:]
 
         data.each { k, v ->
@@ -240,21 +288,18 @@ class ViewService extends BaseService {
             }
         }
 
-        def payload = [*: core, meta: meta]
-        if (data.groupRename) payload.groupRename = data.groupRename as Map
+        Map payload = [*: core, meta: meta]
+        return jsonBlobService.update(token, payload, username)
+    }
 
-        def ret = jsonBlobService.update(token, payload, username)
-
-        if (data.containsKey('isPinned')) {
-            updateState(
-                data.type as String,
-                'default',
-                [userPinned: [(ret.token): data.isPinned]],
-                username
-            )
-        }
-
-        return ret
+    /** Record the user's explicit pinned state for one or more views of a single type. */
+    private void updatePinned(String type, List<String> tokens, Object isPinned, String username) {
+        updateState(
+            type,
+            'default',
+            [userPinned: tokens.collectEntries { [(it): isPinned] }],
+            username
+        )
     }
 
     private trackChange(String msg, Object data) {

--- a/src/main/groovy/io/xh/hoist/exception/ExceptionHandler.groovy
+++ b/src/main/groovy/io/xh/hoist/exception/ExceptionHandler.groovy
@@ -93,6 +93,18 @@ class ExceptionHandler {
             SC_INTERNAL_SERVER_ERROR
     }
 
+    /**
+     * True if the given exception is a routine, expected part of the application flow, as opposed
+     * to an unexpected bug that should require attention.
+     *
+     * Recognizes both {@link RoutineException} and the exception types {@link #preprocess} would
+     * convert into one, so it may also be called by application code on an exception it has caught
+     * itself, before that exception would have reached the response boundary.
+     */
+    boolean isRoutine(Throwable t) {
+        return t instanceof RoutineException || t instanceof grails.validation.ValidationException
+    }
+
 
     //---------------------------------------------
     // Template methods.  For application override
@@ -106,7 +118,7 @@ class ExceptionHandler {
     }
 
     protected boolean shouldLogDebug(Throwable t) {
-        return t instanceof RoutineException
+        return isRoutine(t)
     }
 
     //---------------------------


### PR DESCRIPTION
Stacked on #570, targeting that branch. Client side: xh/hoist-react#4527.

### Why

#570 added a `groupRename: [from:, to:]` reserved key on `JsonBlobService.update`, cascading a group-path rename across sibling blobs using the updated blob as an implicit "anchor". Nothing was misbehaving - the client only ever sent a rename for the global or own-views namespace - but the shape is harder to reason about than it needs to be:

* Scope was inferred from the anchor's owner rather than stated. When the same call also changed ownership (e.g. making a view global), which namespace the rename applied to came down to reading the code.
* A single-blob endpoint carried a bulk operation, so correctness depended on the client nominating an arbitrary member view and the server remembering to exclude it.
* Following the anchor's ownership meant that at the API level, a rename sent against another user's shared view would also rewrite that user's other shared views. Not reachable from the Manage dialog, which offers no rename on the Shared tab.
* The client already knew the scope and discarded it.

### Changes

* New `ViewService.renameGroup` + `xhView/renameGroup` rename or re-parent a group and its whole subtree. Scope is an argument: the global views, or those owned by the caller.
* New `JsonBlobService.renameGroup` rewrites `meta.group` across one owner namespace in a single transaction.
* `ViewService.updateInfo` is a plain single-view update again; the reserved key is gone.
* `bulkUpdateInfo` now reports the token and reason for each view that failed, and no longer reports routine failures (name collisions, access errors) as server errors.
* `isPinned` now takes the view type from the view itself. `updateInfo` and `create` read it from caller-supplied data, which the client does not send on update, so passing `isPinned` failed validation.
* Added `ExceptionHandler.isRoutine()` (used above) and a class-level doc comment for `JsonBlobService`.

Nothing to migrate - the reserved key never shipped. Note that #570's description still describes it.
