### PR TITLE
Don't serialize JSONFormatCached's derived JSON into Hazelcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
   failures that are neither an exception nor an HTTP response. Avoids the need to synthesize a
   throwable - and its fabricated stack trace - purely to flag a span.
 
+### 🐞 Bug Fixes
+
+* `JSONFormatCached` now holds its cached JSON in a `transient` field, so it is no longer serialized
+  into Hazelcast structures (replicated `Cache`/`CachedValue`, `IMap`, Topics) or cross-instance
+  call results. Apps caching `JSONFormatCached` subclasses in replicated structures were shipping -
+  and holding in heap on every instance - a redundant copy of their own data. `getCachedJSON()` now
+  also uses double-checked locking on a `volatile` field, so concurrent first-callers no longer each
+  serialize the same object redundantly.
+
 ### ⚙️ Technical
 
 * `ExceptionHandler` no longer attempts to render an error to an already-committed response,

--- a/docs/json-handling.md
+++ b/docs/json-handling.md
@@ -182,6 +182,11 @@ The first time a `JSONFormatCached` object is serialized, its `formatForJSON()` 
 resulting JSON string is cached. Subsequent serializations write the cached string directly,
 avoiding repeated map creation and serialization.
 
+The cached string is held in a `transient` field, so it is never shipped along with the object into
+Hazelcast structures (a replicated `Cache`/`CachedValue`, an `IMap`, a Topic) or across a
+cross-instance service call — sending derived JSON alongside the fields it came from would inflate
+cluster traffic and per-instance heap. Each instance builds its own copy lazily on first render.
+
 **Use this when:**
 - Objects are serialized in bulk (e.g., large lists rendered to the client)
 - The object's JSON representation doesn't change after construction

--- a/src/main/groovy/io/xh/hoist/json/JSONFormatCached.java
+++ b/src/main/groovy/io/xh/hoist/json/JSONFormatCached.java
@@ -16,19 +16,38 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  *        provided to multiple users).
  *      + Have final / immutable properties that won't change after the first serialization.
  *      + Are serialized in bulk, contain large collections, or are otherwise performance-sensitive.
+ *
+ * The cached JSON is held in a transient field and is therefore *not* included when instances are
+ * serialized into Hazelcast structures (replicated Cache/CachedValue, IMap, Topics) or returned
+ * from cross-instance service calls. Each instance rebuilds its own copy lazily on first render -
+ * shipping the string would duplicate data already carried by the object's own fields, inflating
+ * both cluster traffic and per-instance heap.
  */
 abstract public class JSONFormatCached {
 
-    private String _cache = null;
+    // Transient by design - see class-level comment. Volatile so that concurrent readers reliably
+    // see a cache populated by another thread, rather than redundantly re-serializing.
+    private transient volatile String _cache = null;
 
     public JSONFormatCached() { }
 
     abstract protected Object formatForJSON();
 
     public String getCachedJSON() throws JsonProcessingException {
-        if (_cache == null) {
-            _cache = JSONSerializer.serialize(this.formatForJSON());
+        String ret = _cache;
+        if (ret == null) {
+            // Double-checked locking - only one thread serializes, while the warm path stays a
+            // single volatile read. Locks on `this` rather than a dedicated lock object, which
+            // would be null on instances deserialized by Kryo: it bypasses constructors - and so
+            // field initializers - for classes lacking a no-arg constructor.
+            synchronized (this) {
+                ret = _cache;
+                if (ret == null) {
+                    ret = JSONSerializer.serialize(this.formatForJSON());
+                    _cache = ret;
+                }
+            }
         }
-        return _cache;
+        return ret;
     }
 }

--- a/src/main/groovy/io/xh/hoist/json/JSONFormatCached.java
+++ b/src/main/groovy/io/xh/hoist/json/JSONFormatCached.java
@@ -17,16 +17,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  *      + Have final / immutable properties that won't change after the first serialization.
  *      + Are serialized in bulk, contain large collections, or are otherwise performance-sensitive.
  *
- * The cached JSON is held in a transient field and is therefore *not* included when instances are
- * serialized into Hazelcast structures (replicated Cache/CachedValue, IMap, Topics) or returned
- * from cross-instance service calls. Each instance rebuilds its own copy lazily on first render -
- * shipping the string would duplicate data already carried by the object's own fields, inflating
- * both cluster traffic and per-instance heap.
+ * The cached JSON is transient and so *not* included when instances are serialized into Hazelcast
+ * structures or cross-instance call results - shipping it would duplicate data already carried by
+ * the object's own fields. Each instance rebuilds it lazily on first render.
  */
 abstract public class JSONFormatCached {
 
-    // Transient by design - see class-level comment. Volatile so that concurrent readers reliably
-    // see a cache populated by another thread, rather than redundantly re-serializing.
     private transient volatile String _cache = null;
 
     public JSONFormatCached() { }
@@ -34,17 +30,13 @@ abstract public class JSONFormatCached {
     abstract protected Object formatForJSON();
 
     public String getCachedJSON() throws JsonProcessingException {
+        // Efficient double-checked locking -- lock on cold path only.
         String ret = _cache;
         if (ret == null) {
-            // Double-checked locking - only one thread serializes, while the warm path stays a
-            // single volatile read. Locks on `this` rather than a dedicated lock object, which
-            // would be null on instances deserialized by Kryo: it bypasses constructors - and so
-            // field initializers - for classes lacking a no-arg constructor.
             synchronized (this) {
                 ret = _cache;
                 if (ret == null) {
-                    ret = JSONSerializer.serialize(this.formatForJSON());
-                    _cache = ret;
+                    ret = _cache = JSONSerializer.serialize(this.formatForJSON());
                 }
             }
         }


### PR DESCRIPTION
`JSONFormatCached._cache` was not transient, so the derived JSON string was serialized along with the object into replicated `Cache`/`CachedValue`, `IMap`, and Topic structures, and into cross-instance call results — shipping and heap-retaining a redundant copy of data the object's own fields already carry.

Not a one-time cost at put time: Hoist uses `InMemoryFormat.OBJECT`, which serializes the *live* stored object on demand (remote read, partition migration, joiner sync), so a cache warmed any time after the put gets shipped, repeatedly.

### Changes, in priority order

1. **`transient` on `_cache`** — the actual fix. Each instance rebuilds lazily on first render.
2. **`volatile` on `_cache`** — concurrent readers reliably see a populated cache. Also required for (3).
3. **Double-checked locking in `getCachedJSON()`** — concurrent first-callers no longer each serialize the same object. Locks on `this`; a dedicated lock object would be null on instances Kryo deserializes via its Objenesis fallback, which skips constructors and field initializers.

(1) is the priority and stands on its own. (2) and (3) are negotiable in that order — happy to drop (3), or both, to keep the base class simpler. Benchmarked the locking locally against bulk serialization of large object arrays; overhead did not look problematic relative to the serialization work it guards.

### Heads-up for release

Changes how an existing *app-side* bug presents. For mutable subclasses — which the class docs warn against, but e.g. Toolbox's `Position` and `MarketPrice` are — one warm cache used to replicate, so every instance served identically stale JSON. Each instance now caches independently, so instances can serve divergent JSON for the same object.