### PR TITLE
Validate spec field lengths in ensureRequiredConfigs/PrefsCreated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 41.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* `ensureRequiredConfigsCreated()` and `ensureRequiredPrefsCreated()` now validate every supplied
+  spec against the `name` and `note`/`notes` field length limits before creating anything, throwing
+  with the offending name, actual length, and limit. Violations across all specs are aggregated into
+  a single message. Previously an over-length note surfaced only as a generic GORM
+  `ValidationException` on the create path - and for a config or pref that already existed, not at
+  all, since notes are seeded on create only. That left an over-length note able to boot every
+  established environment while failing the next app started against a fresh database.
+* The length limits are now exposed as constants on the domain classes (`AppConfig.MAX_NAME_LENGTH`,
+  `AppConfig.MAX_NOTE_LENGTH`, `Preference.MAX_NAME_LENGTH`, `Preference.MAX_NOTES_LENGTH`) and
+  referenced by both the GORM constraints and the new checks, so the two cannot drift.
+
 ## 40.4.0 - 2026-08-03
 
 ### 🎁 New Features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -414,6 +414,14 @@ strictly required at startup. This serves as an effective inventory of the appli
 configs, ensures that an app starting against a fresh database has a complete set of entries
 visible and adjustable in the Admin Console, and guarantees consistency across environments.
 
+Every spec is validated against the `AppConfig` field length limits - `name` at
+`AppConfig.MAX_NAME_LENGTH` (50) and `note` at `AppConfig.MAX_NOTE_LENGTH` (1200) - before any
+config is created. Violations are collected across all specs and reported together in a single
+thrown `RuntimeException`, so one restart is enough to see the full set. Note that this check
+covers *every* spec, including those whose config already exists: notes are seeded on create only,
+so an over-length note in an established environment would otherwise go unnoticed until the app was
+next booted against a fresh database.
+
 A deprecated overload accepting `Map<String, Map>` (where the outer key is the config name) is
 still supported for backward compatibility but should be migrated to `ConfigSpec`.
 

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -170,6 +170,13 @@ calls to `PrefService` for a non-existent preference will throw a `RuntimeExcept
 creates any missing preferences with the supplied defaults and logs errors if an existing
 preference has a mismatched type.
 
+Every spec is validated against the `Preference` field length limits - `name` at
+`Preference.MAX_NAME_LENGTH` (50) and `notes` at `Preference.MAX_NOTES_LENGTH` (1200) - before any
+preference is created. Violations are collected across all specs and reported together in a single
+thrown `RuntimeException`. This check covers *every* spec, including those whose preference already
+exists: notes are seeded on create only, so an over-length value in an established environment would
+otherwise go unnoticed until the app was next booted against a fresh database.
+
 A deprecated overload accepting `Map<String, Map>` (where the outer key is the preference name)
 is still supported for backward compatibility but should be migrated to `PreferenceSpec`. Note that
 the old Map API used `note` (singular) for consistency with the former `ensureRequiredConfigsCreated()`

--- a/grails-app/domain/io/xh/hoist/config/AppConfig.groovy
+++ b/grails-app/domain/io/xh/hoist/config/AppConfig.groovy
@@ -25,6 +25,11 @@ class AppConfig implements JSONFormat, LogSupport {
 
     static List TYPES = ['string', 'int', 'long', 'double', 'bool', 'json', 'pwd']
 
+    // Field length limits, applied via `constraints` below and pre-validated for seeded configs
+    // by ConfigSpec.getValidationErrors(). Update in one place only.
+    static final int MAX_NAME_LENGTH = 50
+    static final int MAX_NOTE_LENGTH = 1200
+
     String name
     String value
     String valueType = 'string'
@@ -41,10 +46,10 @@ class AppConfig implements JSONFormat, LogSupport {
     }
 
     static constraints = {
-        name(unique: true, nullable: false, blank: false, maxSize: 50)
+        name(unique: true, nullable: false, blank: false, maxSize: AppConfig.MAX_NAME_LENGTH)
         value(nullable: false, blank: false, validator: AppConfig.isValid)
         valueType(inList: AppConfig.TYPES)
-        note(nullable: true, maxSize: 1200)
+        note(nullable: true, maxSize: AppConfig.MAX_NOTE_LENGTH)
         lastUpdatedBy(nullable: true, maxSize: 50)
         groupName(nullable: false, blank: false)
     }

--- a/grails-app/domain/io/xh/hoist/pref/Preference.groovy
+++ b/grails-app/domain/io/xh/hoist/pref/Preference.groovy
@@ -15,6 +15,11 @@ class Preference implements JSONFormat {
 
     static List TYPES = ['string', 'int', 'long', 'double', 'bool', 'json']
 
+    // Field length limits, applied via `constraints` below and pre-validated for seeded prefs
+    // by PreferenceSpec.getValidationErrors(). Update in one place only.
+    static final int MAX_NAME_LENGTH = 50
+    static final int MAX_NOTES_LENGTH = 1200
+
     String name
     String type = 'string'
     String defaultValue
@@ -33,10 +38,10 @@ class Preference implements JSONFormat {
     }
 
     static constraints = {
-        name(maxSize: 50, unique: true)
+        name(maxSize: Preference.MAX_NAME_LENGTH, unique: true)
         type(maxSize: 20, inList: Preference.TYPES)
         defaultValue(validator: {String val, Preference obj -> obj.isValidForType(val) })
-        notes(nullable: true, maxSize: 1200)
+        notes(nullable: true, maxSize: Preference.MAX_NOTES_LENGTH)
         lastUpdatedBy(nullable: true, maxSize: 50)
         groupName(nullable: false, blank: false)
     }

--- a/grails-app/services/io/xh/hoist/config/ConfigService.groovy
+++ b/grails-app/services/io/xh/hoist/config/ConfigService.groovy
@@ -201,6 +201,15 @@ class ConfigService extends BaseService {
             it instanceof ConfigSpec ? it : new ConfigSpec(it as Map)
         }
 
+        // Validate all specs up-front - including those already in the database - and report every
+        // violation at once, so a single restart is enough to see (and fix) the full set.
+        List<String> errors = configSpecs.collectMany { ConfigSpec spec -> spec.validationErrors }
+        if (errors) {
+            throw new RuntimeException(
+                "Invalid ConfigSpec(s) passed to ensureRequiredConfigsCreated:\n  " + errors.join('\n  ')
+            )
+        }
+
         def currConfigs = AppConfig.list(),
             created = 0
 

--- a/grails-app/services/io/xh/hoist/pref/PrefService.groovy
+++ b/grails-app/services/io/xh/hoist/pref/PrefService.groovy
@@ -133,6 +133,15 @@ class PrefService extends BaseService {
             it instanceof PreferenceSpec ? it : new PreferenceSpec(it as Map)
         }
 
+        // Validate all specs up-front - including those already in the database - and report every
+        // violation at once, so a single restart is enough to see (and fix) the full set.
+        List<String> errors = prefSpecs.collectMany { PreferenceSpec spec -> spec.validationErrors }
+        if (errors) {
+            throw new RuntimeException(
+                "Invalid PreferenceSpec(s) passed to ensureRequiredPrefsCreated:\n  " + errors.join('\n  ')
+            )
+        }
+
         def currPrefs = Preference.list(),
             created = 0
 

--- a/src/main/groovy/io/xh/hoist/config/ConfigSpec.groovy
+++ b/src/main/groovy/io/xh/hoist/config/ConfigSpec.groovy
@@ -32,4 +32,24 @@ class ConfigSpec {
      * Recommended for any structured config with a stable key set — see docs/configuration.md.
      */
     Class<? extends TypedConfigMap> typedClass
+
+    /**
+     * Any violations of the {@link AppConfig} field length limits by this spec, as ready-to-log
+     * messages. Empty if the spec is valid.
+     *
+     * Checked by {@link ConfigService#ensureRequiredConfigsCreated} for *all* specs, including
+     * those whose config already exists in the database. Notes are seeded on create only, so an
+     * over-length note would otherwise go unnoticed in established environments and surface only
+     * when the app is next booted against a fresh database.
+     */
+    List<String> getValidationErrors() {
+        List<String> ret = []
+        if (name?.length() > AppConfig.MAX_NAME_LENGTH) {
+            ret << "Config '$name': name is ${name.length()} chars, exceeding the ${AppConfig.MAX_NAME_LENGTH} char limit".toString()
+        }
+        if (note?.length() > AppConfig.MAX_NOTE_LENGTH) {
+            ret << "Config '$name': note is ${note.length()} chars, exceeding the ${AppConfig.MAX_NOTE_LENGTH} char limit".toString()
+        }
+        return ret
+    }
 }

--- a/src/main/groovy/io/xh/hoist/pref/PreferenceSpec.groovy
+++ b/src/main/groovy/io/xh/hoist/pref/PreferenceSpec.groovy
@@ -25,4 +25,24 @@ class PreferenceSpec {
     Object defaultValue
     String groupName = 'Default'
     String notes
+
+    /**
+     * Any violations of the {@link Preference} field length limits by this spec, as ready-to-log
+     * messages. Empty if the spec is valid.
+     *
+     * Checked by {@link PrefService#ensureRequiredPrefsCreated} for *all* specs, including those
+     * whose preference already exists in the database. Notes are seeded on create only, so an
+     * over-length note would otherwise go unnoticed in established environments and surface only
+     * when the app is next booted against a fresh database.
+     */
+    List<String> getValidationErrors() {
+        List<String> ret = []
+        if (name?.length() > Preference.MAX_NAME_LENGTH) {
+            ret << "Preference '$name': name is ${name.length()} chars, exceeding the ${Preference.MAX_NAME_LENGTH} char limit".toString()
+        }
+        if (notes?.length() > Preference.MAX_NOTES_LENGTH) {
+            ret << "Preference '$name': notes is ${notes.length()} chars, exceeding the ${Preference.MAX_NOTES_LENGTH} char limit".toString()
+        }
+        return ret
+    }
 }


### PR DESCRIPTION
`ensureRequiredConfigsCreated()` / `ensureRequiredPrefsCreated()` now check every spec's `name` and `note`/`notes` against the domain length limits before creating anything, throwing with the offending name, actual length, and limit. Violations are aggregated so one restart shows the full set.

**Why:** an over-length note previously threw only a generic GORM `ValidationException`, and only on the create path. For a config/pref that already existed it wasn't checked at all, since notes are seeded on create only. Net effect: an over-length note boots fine in every established environment, then fails the next app started against a fresh DB.

- Limits extracted as domain constants (`AppConfig.MAX_NOTE_LENGTH` etc.), shared by the GORM constraints and the new checks so they can't drift.
- Check lives in `getValidationErrors()` on `ConfigSpec` / `PreferenceSpec`, which already mirror the domain's seedable fields.