### PR TITLE
Support a dedicated directory-reader app registration for EntraIdService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ detailed, step-by-step upgrade instructions with before/after code examples.
   `ErrorOr.of(usernames)` / `ErrorOr.error(message)` factories, and any code that calls
   `loadUsersForDirectoryGroups` and checks results with `instanceof Set` must read the new
   `ErrorOr.success` / `value` / `error` properties instead.
+* A blank instance config entry is now treated as unset, rather than resolving to an empty string.
+  Environment variables already behaved this way - file and YAML sources now match. Ignored keys are
+  logged at WARN during startup.
 
 ### 🎁 New Features
 
@@ -56,6 +59,11 @@ detailed, step-by-step upgrade instructions with before/after code examples.
   `roleAdmin/directoryGroupsInfo` and `roleAdmin/searchDirectoryGroups` endpoints. These let the
   Admin Console show a display name for each assigned directory group and search the directory by
   name - of particular value with Entra ID, where the stored group identifier is an opaque GUID.
+* Added `AppConfig.NONE` - the placeholder value a bootstrapped but unset config holds, as
+  validation requires a non-blank value. Previously a bare `'none'` string repeated across the
+  framework. Apps can now declare `defaultValue: AppConfig.NONE` rather than retyping the literal.
+* Added `ConfigService.getStringIfSet` and `getPwdIfSet` - both return null when a config holds that
+  placeholder, so a caller can test for "not configured" with a single null check.
 
 ### 📚 Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ detailed, step-by-step upgrade instructions with before/after code examples.
   admin-consented `GroupMember.Read.All` and `User.Read.All` application permissions. The tenant
   and client IDs are standalone configs so that other subsystems can share them and deployments
   can override them per environment via instance configs.
+    * The optional `xhEntraDirectoryClientId` and `xhEntraDirectoryClientSecret` configs point
+      `EntraIdService` at a dedicated directory-reader app registration, for deployments that hold
+      the Graph application permissions on one shared registration rather than on each
+      application's own. The client ID and secret resolve as a matched pair, so the service
+      authenticates either wholly as the application or wholly as the directory reader. The tenant
+      is not overridable. Leave both configs unset to authenticate as the application itself.
 * Added `DirectoryService` - a new interface that `LdapService` and `EntraIdService` both
   implement. It models the resolution of "directory groups" to their member users for
   `DefaultRoleService`, which now selects an enabled implementation to resolve directory-group

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,6 +271,9 @@ myApiEndpoint: https://staging-api.example.com
 Override values are not encrypted, even for `pwd` type configs — they are treated as plaintext.
 If an override value cannot be parsed to the declared type, it is silently ignored (logged at TRACE).
 
+A blank entry counts as no entry, so the config keeps its stored value. Ignored keys are logged at
+WARN during startup.
+
 #### ConfigService
 
 The primary service for reading and managing configuration values.
@@ -291,6 +294,32 @@ String password  = configService.getPwd('apiSecret')          // returns decrypt
 All getters accept an optional `notFoundValue` parameter. If the config doesn't exist and no
 `notFoundValue` is provided, a `RuntimeException` is thrown. A `RuntimeException` is also thrown if
 the requested type doesn't match the config's `valueType`.
+
+##### Unset values and the `AppConfig.NONE` placeholder
+
+`AppConfig` validation requires a non-null, non-blank value, so a config that is bootstrapped but
+not yet set cannot simply hold an empty value. Hoist bootstraps such configs with the
+`AppConfig.NONE` placeholder instead - see the `defaultValue: AppConfig.NONE` entries in
+`BootStrap.ensureRequiredConfigsCreated` for the framework's own.
+
+Declare app-level configs that may be left unset the same way, and read them with
+`getStringIfSet` / `getPwdIfSet`, which return null when the config holds the placeholder:
+
+```groovy
+// In ensureRequiredConfigsCreated
+new ConfigSpec(name: 'myApiKey', valueType: 'pwd', defaultValue: AppConfig.NONE, ...)
+
+// At the point of use
+String apiKey = configService.getPwdIfSet('myApiKey')
+if (!apiKey) throw new RuntimeException('myApiKey not configured')
+```
+
+Use the constant rather than the bare string, so a typo cannot leave a config that reads as set
+when it is not.
+
+Note the distinction between unset and absent. A config holding the placeholder returns null,
+while a config that does not exist throws. These are intended to read a bootstrapped config, and
+are not a way to probe whether one exists.
 
 ##### Typed configs via `TypedConfigMap`
 

--- a/docs/directory-services.md
+++ b/docs/directory-services.md
@@ -133,7 +133,7 @@ with admin consent:
 - `GroupMember.Read.All` - group lookups and transitive membership resolution.
 - `User.Read.All` - user lookups.
 
-Four soft-configs supply the connection:
+These soft-configs supply the connection:
 
 **`xhEntraIdConfig`** (json) - query settings and master switch. Key entries:
 
@@ -159,7 +159,35 @@ whose clients need these values pre-auth (e.g. for OAuth login) should relay the
 
 The service acquires a Graph access token at startup when enabled, so credential problems
 appear in the log immediately. A failure there does not block startup - queries retry token
-acquisition on demand.
+acquisition on demand. The log entry names the client ID in use, and the service's Admin
+Console stats report it as `clientId`.
+
+#### Dedicated Directory-Reader Registration
+
+By default the service authenticates as the application itself, using the shared
+`xhEntraClientId`. That requires a client secret and admin-consented Graph permissions on
+every application's own registration. Deployments that would rather hold those permissions on
+a single registration - shared across several applications - can point the service at it with
+two optional configs:
+
+- **`xhEntraDirectoryClientId`** (string) - client ID (GUID) of the directory-reader
+  registration.
+- **`xhEntraDirectoryClientSecret`** (pwd) - client secret for that registration.
+
+When `xhEntraDirectoryClientId` is set, the service uses it together with
+`xhEntraDirectoryClientSecret`. When it is not, the service uses `xhEntraClientId` with
+`xhEntraClientSecret`. The client ID and secret always resolve as a matched pair, so the
+service authenticates either wholly as the application or wholly as the directory reader.
+Both configs are standalone, so a deployment can enable the override in one environment only,
+via an instance config / environment variable.
+
+`xhEntraClientId` keeps its meaning either way - the application's own registration, shared
+with client-side OAuth. Only this service follows the override.
+
+The tenant is deliberately not overridable. A directory in a second tenant would return group
+object IDs and usernames that do not line up with the tenant that authenticates the
+application's own users, and cross-tenant app-only Graph access needs a multi-tenant
+registration consented into the target tenant.
 
 ## Username Mapping
 

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -70,7 +70,7 @@
             "mcpCategory": "concept",
             "viewerCategory": "core-features",
             "description": "Database-backed soft configuration with typed values.",
-            "keywords": ["AppConfig", "ConfigService", "clientVisible", "pwd", "encryption", "xhConfigChanged", "TypedConfigMap", "getObject"]
+            "keywords": ["AppConfig", "ConfigService", "clientVisible", "pwd", "encryption", "xhConfigChanged", "TypedConfigMap", "getObject", "getStringIfSet"]
         },
         {
             "id": "docs/preferences.md",

--- a/docs/upgrade-notes/v41-upgrade-notes.md
+++ b/docs/upgrade-notes/v41-upgrade-notes.md
@@ -17,6 +17,8 @@ The most significant app-level impacts are:
   small mechanical update. Apps that do not can upgrade with no code changes.
 - **Entra ID directory groups** - apps whose corporate directory lives in Entra ID can now
   resolve role memberships from Entra ID groups, without LDAP connectivity.
+- **Blank instance config entries are ignored** - a second breaking change, with no expected app
+  impact. Only a deployment that sets an instance config to a blank value on purpose is affected.
 
 Apps that use `LdapService` today do not need to change their configs or role data.
 
@@ -102,7 +104,73 @@ lookup.each { group, result ->
 
 See Toolbox's `RoleService` for a complete, working override migrated to the new contract.
 
-### 3. Optional - resolve directory groups from Entra ID
+### 3. Confirm no instance config is deliberately set to a blank value
+
+A blank instance config entry is now treated as unset - an empty file in an instance config
+directory, or `key: ""` in an instance config YAML. Environment variables already behaved this way.
+
+Blank entries are logged at WARN during startup, naming each ignored key. Most apps require no
+action.
+
+### 4. Optional - adopt `AppConfig.NONE` in config declarations
+
+The placeholder value that Hoist bootstraps into a config an app may leave unset is now available
+as the `AppConfig.NONE` constant. The bare `'none'` string keeps working, so this step is a cleanup
+rather than a required change - but the constant removes a class of typo that leaves a config
+reading as set when it is not.
+
+Find bare placeholder strings in the app's own config declarations:
+
+```bash
+grep -rnE "defaultValue: *['\"]none['\"]" grails-app/
+```
+
+**Before:**
+
+```groovy
+new ConfigSpec(
+    name: 'myApiKey',
+    valueType: 'pwd',
+    defaultValue: 'none',
+    groupName: 'MyApp'
+)
+```
+
+**After** - add `import io.xh.hoist.config.AppConfig` to the app's `BootStrap.groovy`:
+
+```groovy
+new ConfigSpec(
+    name: 'myApiKey',
+    valueType: 'pwd',
+    defaultValue: AppConfig.NONE,
+    groupName: 'MyApp'
+)
+```
+
+Then check the read side, where the new `getStringIfSet` / `getPwdIfSet` getters replace the
+comparison entirely:
+
+```bash
+grep -rn "== 'none'" grails-app/ src/
+```
+
+**Before:**
+
+```groovy
+String apiKey = configService.getPwd('myApiKey')
+if (!apiKey || apiKey == 'none') throw new RuntimeException('myApiKey not configured')
+```
+
+**After:**
+
+```groovy
+String apiKey = configService.getPwdIfSet('myApiKey')
+if (!apiKey) throw new RuntimeException('myApiKey not configured')
+```
+
+See [`configuration.md`](../configuration.md) for the full convention.
+
+### 5. Optional - resolve directory groups from Entra ID
 
 Apps whose corporate directory lives in Entra ID can enable the new `EntraIdService` and
 retire their LDAP connectivity. This requires an Entra ID app registration with
@@ -120,6 +188,7 @@ After completing all steps:
 
 - [ ] `./gradlew compileGroovy` succeeds
 - [ ] Application starts without errors
+- [ ] No unexpected `Ignoring N blank InstanceConfig entries` WARN in the startup log
 - [ ] Users receive their expected roles, including directory-group-based memberships
 - [ ] The Roles tab in the Admin Console loads and shows effective members
 - [ ] For apps with a form-based login backup: `login()` still authenticates

--- a/grails-app/domain/io/xh/hoist/config/AppConfig.groovy
+++ b/grails-app/domain/io/xh/hoist/config/AppConfig.groovy
@@ -25,6 +25,15 @@ class AppConfig implements JSONFormat, LogSupport {
 
     static List TYPES = ['string', 'int', 'long', 'double', 'bool', 'json', 'pwd']
 
+    /**
+     * Placeholder value for a config that has not been set. Validation requires a non-null,
+     * non-blank `value`, so a config that is bootstrapped but not yet configured holds this
+     * instead. Bootstrap a config that an app may leave unset with this as its `defaultValue`, and
+     * read it with {@link io.xh.hoist.config.ConfigService#getStringIfSet} / `getPwdIfSet`, which
+     * map it back to null.
+     */
+    static final String NONE = 'none'
+
     String name
     String value
     String valueType = 'string'

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -11,6 +11,7 @@ import io.xh.hoist.admin.ConnPoolMonitoringConfig
 import io.xh.hoist.admin.MemoryMonitoringConfig
 import io.xh.hoist.alertbanner.AlertBannerConfig
 import io.xh.hoist.cluster.ClusterService
+import io.xh.hoist.config.AppConfig
 import io.xh.hoist.config.ChangelogConfig
 import io.xh.hoist.config.ConfigSpec
 import io.xh.hoist.config.IdleConfig
@@ -183,21 +184,21 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhEmailFilter',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
                 note: 'Comma-separated list of email addresses to which Hoist EmailService can send mail. For testing / dev purposes. If specified, emails to addresses not in this list will be quietly dropped. Value "none" does not filter recipients.'
             ),
             new ConfigSpec(
                 name: 'xhEmailOverride',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
                 note: 'Email address to which Hoist emailService should send all mail, regardless of specified recipient. For testing / dev purposes. Use to test actual sending of mails while still not mailing end-users. Value "none" disables any override.'
             ),
             new ConfigSpec(
                 name: 'xhEmailSupport',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 clientVisible: true,
                 groupName: 'xh.io',
                 note: 'Email address to which support and feedback submissions should be sent. Value "none" to disable support emails.'
@@ -237,21 +238,21 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhEntraTenantId',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
                 note: 'Tenant ID (GUID) of the Microsoft Entra ID tenant for this application. Referenced by EntraIdService and any other subsystem that works with the tenant. Commonly overridden per environment via an instance config / environment variable. Relay to pre-auth clients (e.g. for OAuth login) via the app AuthenticationService.getClientConfig(), where needed.'
             ),
             new ConfigSpec(
                 name: 'xhEntraClientId',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
                 note: 'Client ID (GUID) of the Entra ID app registration for this application. Referenced by EntraIdService and any other subsystem that works with the registration. Commonly overridden per environment via an instance config / environment variable. Relay to pre-auth clients (e.g. for OAuth login) via the app AuthenticationService.getClientConfig(), where needed.'
             ),
             new ConfigSpec(
                 name: 'xhEntraClientSecret',
                 valueType: 'pwd',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
                 note: 'Client secret for the Entra ID app registration used by EntraIdService.'
             ),
@@ -312,13 +313,13 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhLdapUsername',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io'
             ),
             new ConfigSpec(
                 name: 'xhLdapPassword',
                 valueType: 'pwd',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io'
             ),
             new ConfigSpec(
@@ -349,7 +350,7 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhMonitorEmailRecipients',
                 valueType: 'string',
-                defaultValue: 'none',
+                defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
                 note: 'Email address to which status monitor alerts should be sent. Value "none" disables emailed alerts.'
             ),

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -254,7 +254,21 @@ class BootStrap implements LogSupport {
                 valueType: 'pwd',
                 defaultValue: AppConfig.NONE,
                 groupName: 'xh.io',
-                note: 'Client secret for the Entra ID app registration used by EntraIdService.'
+                note: 'Client secret for the app registration identified by xhEntraClientId. Used by EntraIdService to authenticate to Microsoft Graph, unless xhEntraDirectoryClientId is set.'
+            ),
+            new ConfigSpec(
+                name: 'xhEntraDirectoryClientId',
+                valueType: 'string',
+                defaultValue: AppConfig.NONE,
+                groupName: 'xh.io',
+                note: 'Optional client ID (GUID) of a dedicated directory-reader app registration for EntraIdService to use in place of the shared xhEntraClientId. Set this when the Graph application permissions are held by their own registration - e.g. one registration shared by several applications. Requires xhEntraDirectoryClientSecret. Leave unset to authenticate as the application itself.'
+            ),
+            new ConfigSpec(
+                name: 'xhEntraDirectoryClientSecret',
+                valueType: 'pwd',
+                defaultValue: AppConfig.NONE,
+                groupName: 'xh.io',
+                note: 'Client secret for the app registration identified by xhEntraDirectoryClientId. Required when that config is set, and ignored when it is not.'
             ),
             new ConfigSpec(
                 name: 'xhEnvPollConfig',

--- a/grails-app/services/io/xh/hoist/config/ConfigService.groovy
+++ b/grails-app/services/io/xh/hoist/config/ConfigService.groovy
@@ -70,6 +70,27 @@ class ConfigService extends BaseService {
     }
 
     /**
+     * Value of a string config, or null if its value has not been set.
+     *
+     * A string or pwd config that an app may legitimately leave unset is bootstrapped with the
+     * {@link AppConfig#NONE} placeholder value, as AppConfig validation requires a non-null,
+     * non-blank value. Use this in place of {@link #getString} to read such a config, and treat a
+     * null result as "not configured".
+     *
+     * Note the distinction between unset and absent - a config holding the placeholder returns
+     * null, while a config that does not exist throws. These are intended to read a bootstrapped
+     * config, and are not a way to probe whether one exists.
+     */
+    String getStringIfSet(String name) {
+        return valueIfSet(getString(name))
+    }
+
+    /** Value of a pwd config, or null if its value has not been set - see {@link #getStringIfSet}. */
+    String getPwdIfSet(String name) {
+        return valueIfSet(getPwd(name))
+    }
+
+    /**
      * Load a typed representation of a JSON soft config, with declared property defaults
      * applied for any keys missing from the stored value.
      *
@@ -329,6 +350,11 @@ class ConfigService extends BaseService {
                 "defaults should live on ${asTyped.simpleName} - pass defaultValue: [:] in the ConfigSpec"
             )
         }
+    }
+
+    /** Map the {@link AppConfig#NONE} placeholder to null - see {@link #getStringIfSet}. */
+    private String valueIfSet(String value) {
+        return value == AppConfig.NONE ? null : value
     }
 
     @ReadOnly

--- a/grails-app/services/io/xh/hoist/email/EmailService.groovy
+++ b/grails-app/services/io/xh/hoist/email/EmailService.groovy
@@ -7,6 +7,7 @@
 package io.xh.hoist.email
 
 import io.xh.hoist.BaseService
+import io.xh.hoist.config.AppConfig
 import io.xh.hoist.util.Utils
 
 
@@ -161,11 +162,11 @@ class EmailService extends BaseService {
      *  Parse a comma delimited list of email addresses into a list of trimmed, properly
      *  formatted addresses, appending the xhEmailDefaultDomain config to any unqualified address.
      *
-     *  Includes special support for returning null if given the string 'none', to allow for
+     *  Includes special support for returning null if given {@link AppConfig#NONE}, to allow for
      *  sourcing optional / potentially-empty addresses from string configs.
      */
     List<String> parseAddresses(String s) {
-        return s == 'none' ? null : formatAddresses(s)
+        return s == AppConfig.NONE ? null : formatAddresses(s)
     }
 
     Map getAdminStats() {

--- a/grails-app/services/io/xh/hoist/entra/EntraIdService.groovy
+++ b/grails-app/services/io/xh/hoist/entra/EntraIdService.groovy
@@ -494,12 +494,12 @@ class EntraIdService extends BaseService implements DirectoryService {
     private synchronized IConfidentialClientApplication getMsalClient() {
         if (!_msalClient) {
             String tenantId = getTenantId(),
-                clientId = configValue('xhEntraClientId')
+                clientId = configService.getStringIfSet('xhEntraClientId')
             if (!tenantId || !clientId) {
                 throw new RuntimeException('EntraIdService enabled but tenant/client not configured - check xhEntraTenantId and xhEntraClientId app configs.')
             }
-            def secret = configService.getPwd('xhEntraClientSecret')
-            if (!secret || secret == 'none') {
+            String secret = configService.getPwdIfSet('xhEntraClientSecret')
+            if (!secret) {
                 throw new RuntimeException('EntraIdService enabled but client secret not configured - check xhEntraClientSecret app config.')
             }
             _msalClient = ConfidentialClientApplication
@@ -511,13 +511,7 @@ class EntraIdService extends BaseService implements DirectoryService {
     }
 
     private String getTenantId() {
-        configValue('xhEntraTenantId')
-    }
-
-    /** Value of a standalone string config, with the 'none' placeholder mapped to null. */
-    private String configValue(String name) {
-        String ret = configService.getString(name)
-        ret == 'none' ? null : ret
+        configService.getStringIfSet('xhEntraTenantId')
     }
 
     private synchronized JSONClient getJsonClient() {

--- a/grails-app/services/io/xh/hoist/entra/EntraIdService.groovy
+++ b/grails-app/services/io/xh/hoist/entra/EntraIdService.groovy
@@ -59,6 +59,15 @@ import static java.util.Collections.emptyMap
  * environment variables. Apps whose clients need them pre-auth (e.g. for OAuth login) should
  * relay them via their AuthenticationService's `getClientConfig()`.
  *
+ * <p>This service can instead authenticate as a dedicated "directory reader" app registration,
+ * for deployments that hold the Graph application permissions on their own registration rather
+ * than on each application's. Set the optional `xhEntraDirectoryClientId` and
+ * `xhEntraDirectoryClientSecret` configs to do so. The client ID and secret always resolve as a
+ * matched pair, so an app either authenticates wholly as itself or wholly as the directory
+ * reader. The tenant is deliberately not overridable - a directory in another tenant would
+ * return group IDs and usernames that do not line up with the tenant authenticating the app's
+ * own users.
+ *
  * <p>Results are cached per query for `xhEntraIdConfig.cacheExpireSecs`. Queries run with
  * `strictMode = false` will log and absorb failures, so callers can receive partial results.
  * Graph throttling (HTTP 429) and server errors are retried a bounded number of times before
@@ -70,7 +79,8 @@ class EntraIdService extends BaseService implements DirectoryService {
     ConfigService configService
 
     static clearCachesConfigs = [
-        'xhEntraIdConfig', 'xhEntraTenantId', 'xhEntraClientId', 'xhEntraClientSecret'
+        'xhEntraIdConfig', 'xhEntraTenantId', 'xhEntraClientId', 'xhEntraClientSecret',
+        'xhEntraDirectoryClientId', 'xhEntraDirectoryClientSecret'
     ]
 
     static final String GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0'
@@ -102,7 +112,11 @@ class EntraIdService extends BaseService implements DirectoryService {
         if (enabled) {
             try {
                 acquireAccessToken()
-                logInfo('Acquired Microsoft Graph access token', [tenantId: tenantId])
+                logInfo('Acquired Microsoft Graph access token', [
+                    tenantId: tenantId,
+                    clientId: serviceClientId,
+                    dedicatedDirectoryReader: directoryClientId != null
+                ])
             } catch (Exception e) {
                 logError('Failed to acquire Microsoft Graph access token on startup', e)
             }
@@ -344,8 +358,12 @@ class EntraIdService extends BaseService implements DirectoryService {
     // Admin stats
     //------------------------
     Map getAdminStats() {[
-        config: configForAdminStats('xhEntraIdConfig', 'xhEntraTenantId', 'xhEntraClientId'),
-        enabled: enabled
+        config: configForAdminStats(
+            'xhEntraIdConfig', 'xhEntraTenantId', 'xhEntraClientId', 'xhEntraDirectoryClientId'
+        ),
+        enabled: enabled,
+        // The registration actually in use - the app's own, or a dedicated directory reader.
+        clientId: serviceClientId
     ]}
 
     List<String> getComparableAdminStats() { ['enabled'] }
@@ -493,15 +511,25 @@ class EntraIdService extends BaseService implements DirectoryService {
 
     private synchronized IConfidentialClientApplication getMsalClient() {
         if (!_msalClient) {
+            boolean dedicated = directoryClientId != null
             String tenantId = getTenantId(),
-                clientId = configService.getStringIfSet('xhEntraClientId')
+                clientId = getServiceClientId(),
+                clientIdConfig = dedicated ? 'xhEntraDirectoryClientId' : 'xhEntraClientId',
+                secretConfig = dedicated ? 'xhEntraDirectoryClientSecret' : 'xhEntraClientSecret'
+
             if (!tenantId || !clientId) {
-                throw new RuntimeException('EntraIdService enabled but tenant/client not configured - check xhEntraTenantId and xhEntraClientId app configs.')
+                throw new RuntimeException("EntraIdService enabled but tenant/client not configured - check xhEntraTenantId and $clientIdConfig app configs.")
             }
-            String secret = configService.getPwdIfSet('xhEntraClientSecret')
+            if (!GUID_PATTERN.matcher(clientId).matches()) {
+                throw new RuntimeException("Invalid $clientIdConfig value '$clientId' - expected the app registration's client ID (GUID).")
+            }
+
+            // The secret pairs with the client ID resolved above - the two are never mixed.
+            String secret = configService.getPwdIfSet(secretConfig)
             if (!secret) {
-                throw new RuntimeException('EntraIdService enabled but client secret not configured - check xhEntraClientSecret app config.')
+                throw new RuntimeException("EntraIdService enabled but client secret not configured - check $secretConfig app config.")
             }
+
             _msalClient = ConfidentialClientApplication
                 .builder(clientId, ClientCredentialFactory.createFromSecret(secret))
                 .authority("https://login.microsoftonline.com/${tenantId}")
@@ -512,6 +540,19 @@ class EntraIdService extends BaseService implements DirectoryService {
 
     private String getTenantId() {
         configService.getStringIfSet('xhEntraTenantId')
+    }
+
+    /**
+     * Client ID this service authenticates to Graph as - the dedicated directory-reader
+     * registration when configured, otherwise the application's own shared registration.
+     */
+    private String getServiceClientId() {
+        directoryClientId ?: configService.getStringIfSet('xhEntraClientId')
+    }
+
+    /** Client ID of the dedicated directory-reader registration, or null if not configured. */
+    private String getDirectoryClientId() {
+        configService.getStringIfSet('xhEntraDirectoryClientId')
     }
 
     private synchronized JSONClient getJsonClient() {

--- a/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
+++ b/grails-app/services/io/xh/hoist/ldap/LdapService.groovy
@@ -289,10 +289,10 @@ class LdapService extends BaseService implements DirectoryService {
     @CompileDynamic
     private <T extends LdapObject> List<T> doQuery(LdapConfig.LdapServerOptions server, String baseFilter, Class<T> objType, boolean strictMode) {
         ensureEnabled()
-        if (queryUsername == 'none') throw new RuntimeException('LdapService enabled but query user not configured - check xhLdapUsername app config, or disable via xhLdapConfig.')
-        // Never bind with the 'none' placeholder - repeated binds with a bad password can lock
-        // out the query account under an AD lockout policy.
-        if (!queryUserPwd || queryUserPwd == 'none') throw new RuntimeException('LdapService enabled but query user password not configured - check xhLdapPassword app config, or disable via xhLdapConfig.')
+        if (!queryUsername) throw new RuntimeException('LdapService enabled but query user not configured - check xhLdapUsername app config, or disable via xhLdapConfig.')
+        // Never bind with an unset password - repeated binds with a bad password can lock out the
+        // query account under an AD lockout policy.
+        if (!queryUserPwd) throw new RuntimeException('LdapService enabled but query user password not configured - check xhLdapPassword app config, or disable via xhLdapConfig.')
 
         boolean isPerson = LdapPerson.class.isAssignableFrom(objType)
         // Cache key MUST include `baseDn` alongside `host` and `filter`. Apps commonly
@@ -380,11 +380,11 @@ class LdapService extends BaseService implements DirectoryService {
     }
 
     private String getQueryUsername() {
-        configService.getString('xhLdapUsername')
+        configService.getStringIfSet('xhLdapUsername')
     }
 
     private String getQueryUserPwd() {
-        configService.getPwd('xhLdapPassword')
+        configService.getPwdIfSet('xhLdapPassword')
     }
 
     void clearCaches() {

--- a/src/main/groovy/io/xh/hoist/util/InstanceConfigUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/InstanceConfigUtils.groovy
@@ -109,6 +109,17 @@ class InstanceConfigUtils {
             println "InstanceConfigUtils [ERROR] | InstanceConfig file found but could not be parsed | $configFilename | $t.message"
         }
 
+        // Drop blank entries, so a blank entry reads as no entry at all. Env vars already behave
+        // this way via the `?:` in getInstanceConfig - this brings the file and YAML sources into
+        // line. Both can yield a blank without meaning to: an empty file in a config directory, or
+        // a templated YAML that interpolates an unset variable as `key: ""`. Note the test is on a
+        // string view of the value only - retained values are returned exactly as loaded.
+        def blankKeys = ret.findAll { !it.value?.toString()?.trim() }.keySet()
+        if (blankKeys) {
+            println "InstanceConfigUtils [WARN] | Ignoring ${blankKeys.size()} blank InstanceConfig entries | ${blankKeys.join(', ')}"
+            ret = ret.findAll { !blankKeys.contains(it.key) }
+        }
+
         return ret
     }
 


### PR DESCRIPTION
**Draft, on hold. Not ready to merge.**

Whether we want this at all depends on client signal. It is only worth taking if enterprise deployments go the shared directory-reader app registration route, rather than holding Graph application permissions on each application's own registration. Parking the work here so it is ready if that lands.

Stacked on #591. Base is `config-service-if-set-getters`, so the diff shows only the Entra work. #591 has to merge first.

### What it does

`EntraIdService` authenticates to Microsoft Graph as the application itself, using the shared `xhEntraClientId` and `xhEntraClientSecret`. That requires a client secret and admin-consented Graph application permissions on every application's own registration. This adds optional `xhEntraDirectoryClientId` and `xhEntraDirectoryClientSecret` configs to point the service at one shared registration instead.

- The client ID and secret resolve as a matched pair, so the service authenticates either wholly as the application or wholly as the directory reader. Pairing a directory secret with the application's own client ID is not reachable.
- `xhEntraClientId` keeps its existing meaning: the application's own registration, shared with client-side OAuth. Only this service follows the override.
- The tenant is deliberately not overridable. A directory in a second tenant would return group object IDs and usernames that do not line up with the tenant authenticating the application's own users, and cross-tenant app-only Graph access needs a multi-tenant registration consented into the target tenant.
- The resolved client ID is GUID-validated, named in every configuration error message, logged at startup alongside a `dedicatedDirectoryReader` flag, and reported in the service's Admin Console stats. Both configs are in `clearCachesConfigs`.

### Open question for review

Both configs are bootstrapped, so they appear in every app's config editor defaulted to `AppConfig.NONE`, including for apps that will never use them. That is deliberate: an un-bootstrapped config cannot be overridden by an instance config, because `AppConfig.overrideValue` only runs for an existing row, and per-environment override is the main reason to want these. The cost is two more rows in the config table.
