### PR TITLE
Fix InstanceConfigUtils regressions from #591

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,6 @@ detailed, step-by-step upgrade instructions with before/after code examples.
   `ErrorOr.of(usernames)` / `ErrorOr.error(message)` factories, and any code that calls
   `loadUsersForDirectoryGroups` and checks results with `instanceof Set` must read the new
   `ErrorOr.success` / `value` / `error` properties instead.
-* A blank instance config entry is now treated as unset, rather than resolving to an empty string.
-  Environment variables already behaved this way - file and YAML sources now match. Ignored keys are
-  logged at WARN during startup.
 
 ### 🎁 New Features
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,10 +123,15 @@ individual files.
 If both an environment variable and a file-based entry exist for the same key, the environment
 variable wins.
 
-All values are read as Strings - a YAML boolean or number is converted on load, so `useH2: true`
-reads as `'true'`. A blank file or YAML entry resolves to an empty string, distinct from an absent
-key, which resolves to null. An empty environment variable reads as unset and falls through to any
-file-based entry for the same key. Blank entries are logged at INFO during startup.
+All values are read as Strings. YAML scalars are converted on load, so `useH2: true` reads as
+`'true'` and `port: 8080` reads as `'8080'`. Quote any value that must be preserved verbatim, as
+unquoted dates parse to `Date` and stringify in the JVM's default timezone.
+
+Blank and absent entries are distinct. An explicitly empty entry resolves to an empty String,
+whether it comes from `key: ""` in YAML or an empty file in a config directory. An absent key
+resolves to null, as does a YAML key written with no value at all (`key:`). An empty environment
+variable reads as unset and falls through to any file-based entry for the same key. Blank entries
+are logged at INFO during startup, as they can arrive unintentionally.
 
 ### Common Instance Config Keys
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,11 @@ individual files.
 If both an environment variable and a file-based entry exist for the same key, the environment
 variable wins.
 
+All values are read as Strings - a YAML boolean or number is converted on load, so `useH2: true`
+reads as `'true'`. A blank file or YAML entry resolves to an empty string, distinct from an absent
+key, which resolves to null. An empty environment variable reads as unset and falls through to any
+file-based entry for the same key. Blank entries are logged at INFO during startup.
+
 ### Common Instance Config Keys
 
 | Key | Purpose |
@@ -270,9 +275,6 @@ myApiEndpoint: https://staging-api.example.com
 
 Override values are not encrypted, even for `pwd` type configs — they are treated as plaintext.
 If an override value cannot be parsed to the declared type, it is silently ignored (logged at TRACE).
-
-A blank entry counts as no entry, so the config keeps its stored value. Ignored keys are logged at
-WARN during startup.
 
 #### ConfigService
 

--- a/docs/upgrade-notes/v41-upgrade-notes.md
+++ b/docs/upgrade-notes/v41-upgrade-notes.md
@@ -17,8 +17,6 @@ The most significant app-level impacts are:
   small mechanical update. Apps that do not can upgrade with no code changes.
 - **Entra ID directory groups** - apps whose corporate directory lives in Entra ID can now
   resolve role memberships from Entra ID groups, without LDAP connectivity.
-- **Blank instance config entries are ignored** - a second breaking change, with no expected app
-  impact. Only a deployment that sets an instance config to a blank value on purpose is affected.
 
 Apps that use `LdapService` today do not need to change their configs or role data.
 
@@ -104,15 +102,7 @@ lookup.each { group, result ->
 
 See Toolbox's `RoleService` for a complete, working override migrated to the new contract.
 
-### 3. Confirm no instance config is deliberately set to a blank value
-
-A blank instance config entry is now treated as unset - an empty file in an instance config
-directory, or `key: ""` in an instance config YAML. Environment variables already behaved this way.
-
-Blank entries are logged at WARN during startup, naming each ignored key. Most apps require no
-action.
-
-### 4. Optional - adopt `AppConfig.NONE` in config declarations
+### 3. Optional - adopt `AppConfig.NONE` in config declarations
 
 The placeholder value that Hoist bootstraps into a config an app may leave unset is now available
 as the `AppConfig.NONE` constant. The bare `'none'` string keeps working, so this step is a cleanup
@@ -170,7 +160,7 @@ if (!apiKey) throw new RuntimeException('myApiKey not configured')
 
 See [`configuration.md`](../configuration.md) for the full convention.
 
-### 5. Optional - resolve directory groups from Entra ID
+### 4. Optional - resolve directory groups from Entra ID
 
 Apps whose corporate directory lives in Entra ID can enable the new `EntraIdService` and
 retire their LDAP connectivity. This requires an Entra ID app registration with
@@ -188,7 +178,6 @@ After completing all steps:
 
 - [ ] `./gradlew compileGroovy` succeeds
 - [ ] Application starts without errors
-- [ ] No unexpected `Ignoring N blank InstanceConfig entries` WARN in the startup log
 - [ ] Users receive their expected roles, including directory-group-based memberships
 - [ ] The Roles tab in the Admin Console loads and shows effective members
 - [ ] For apps with a form-based login backup: `login()` still authenticates

--- a/src/main/groovy/io/xh/hoist/util/InstanceConfigUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/InstanceConfigUtils.groovy
@@ -109,15 +109,12 @@ class InstanceConfigUtils {
             println "InstanceConfigUtils [ERROR] | InstanceConfig file found but could not be parsed | $configFilename | $t.message"
         }
 
-        // Drop blank entries, so a blank entry reads as no entry at all. Env vars already behave
-        // this way via the `?:` in getInstanceConfig - this brings the file and YAML sources into
-        // line. Both can yield a blank without meaning to: an empty file in a config directory, or
-        // a templated YAML that interpolates an unset variable as `key: ""`. Note the test is on a
-        // string view of the value only - retained values are returned exactly as loaded.
-        def blankKeys = ret.findAll { !it.value?.toString()?.trim() }.keySet()
+        // A blank entry resolves as an empty string, distinct from an absent entry, which resolves
+        // as null. Log blanks at startup, as they can arrive unintentionally - e.g. an empty file
+        // in a config directory, or a templated YAML that interpolates an unset variable.
+        def blankKeys = ret.findAll { !it.value?.trim() }.keySet()
         if (blankKeys) {
-            println "InstanceConfigUtils [WARN] | Ignoring ${blankKeys.size()} blank InstanceConfig entries | ${blankKeys.join(', ')}"
-            ret = ret.findAll { !blankKeys.contains(it.key) }
+            println "InstanceConfigUtils [INFO] | Found ${blankKeys.size()} blank InstanceConfig entries | ${blankKeys.join(', ')}"
         }
 
         return ret
@@ -164,7 +161,10 @@ class InstanceConfigUtils {
     }
 
     private static Map<String, String> loadFromYaml(File configFile) {
-        def ret = new Yaml().loadAs(configFile.newInputStream(), Map)
+        // SnakeYAML parses unquoted scalars into native types - booleans, numbers - so normalize
+        // to Strings here, honoring this class's contract of String keys and values throughout.
+        Map loaded = new Yaml().loadAs(configFile.newInputStream(), Map)
+        def ret = loaded.collectEntries { k, v -> [k.toString(), v?.toString()] } as Map<String, String>
         logLoadCount(ret, configFile)
         return ret
     }


### PR DESCRIPTION
Fixes #594 - two regressions in `InstanceConfigUtils.readConfigs()` from #591, both hit by Toolbox on startup against the current snapshot.

### Changes

- **Fix `ClassCastException` on non-String YAML values.** The blank-entry filter ran under `@CompileStatic` against a `Map<String, String>` actually holding SnakeYAML-typed values, so a checkcast threw before the `toString()` could run - in the static initializer, killing startup for any app with an unquoted `false`/`0`/etc in its instance config YAML. `loadFromYaml` now normalizes keys and values to Strings at the load boundary, making the declared types true at runtime and matching the class's documented String-only contract. Unquoted scalars read exactly as they did pre-#591 (`false` -> `'false'`, `0` -> `'0'`).
- **Restore blank entries.** Dropping them erased the established distinction between a deliberately-empty value (`''`) and an absent one (`null`), which Toolbox relies on for its datasource password. Blank file/YAML entries resolve to `''` again. The startup log listing blank keys is kept for diagnosability, downgraded to INFO and reworded.
- **Docs**: removed the reverted breaking change from CHANGELOG and the v41 upgrade notes, and added a short paragraph to `configuration.md` documenting the actual value contract (String conversion, `''` vs `null`, empty env vars read as unset).

### Verification

Ran the compiled class directly against real YAML files, a config directory, and env vars, comparing current code to a pre-#591 baseline build. All scenarios now match baseline: no crash on typed scalars, `''` restored for blanks, env var precedence and empty-env behavior unchanged. Notably the baseline run showed unquoted YAML booleans/numbers worked before #591 via Groovy's implicit String coercion, so the type crash was a true regression, not a latent bug surfaced.