### PR TITLE
Seed typed configs with empty object when defaultValue omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## 42.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* `ConfigService.ensureRequiredConfigsCreated` now seeds a `ConfigSpec` that has a `typedClass` but
+  no `defaultValue` with an empty JSON object. Apps can omit `defaultValue` for typed configs. An
+  explicit `defaultValue: [:]` continues to work.
+
 ## 41.0.0 - 2026-08-25
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - most apps require no changes)

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -509,8 +509,9 @@ def endpoint = m.endpoint ?: 'https://prices.example.com'
 ```
 
 The class must extend `TypedConfigMap` and be registered with `typedClass:` on its
-`ensureRequiredConfigsCreated` entry. See [Configuration](configuration.md#typed-configs-via-typedconfigmap)
-for the full guide.
+`ensureRequiredConfigsCreated` entry. Omit `defaultValue` on that entry — the class is the single
+source of defaults, and a non-empty `defaultValue` logs a WARN at startup. See
+[Configuration](configuration.md#typed-configs-via-typedconfigmap) for the full guide.
 
 ## Controllers and Security
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -335,14 +335,16 @@ and wire it in via the `typedClass:` field on the config's `ConfigSpec` entry pa
 `ensureRequiredConfigsCreated`. This gives you:
 
 1. **One source of truth for shape + defaults.** Property initializers on the class are the
-   fallback values; when the stored map is missing a key, the declared default applies.
+   fallback values; when the stored map is missing a key, the declared default applies. Omit
+   `defaultValue` from the `ConfigSpec` — a missing config is seeded as an empty JSON object
+   (`{}`), and the typed class fills in every key at read time.
 2. **Typed server-side reads** via `configService.getObject(Class)`.
 3. **Populated client payloads** — for `clientVisible: true` configs, the map sent to the
    client via `getClientConfig()` is filled in through the typed class, so the same defaults
    reach browser code without duplicating them in TypeScript.
-4. **Startup drift detection** — a `WARN` is logged when a typed-class property default
-   disagrees with the BootStrap `defaultValue` for the same key, flagging stale declarations
-   on either side.
+4. **Startup guard against duplicated defaults** — a `WARN` is logged when a spec with a
+   `typedClass` also declares a non-empty `defaultValue`, since the two would otherwise drift.
+   An explicit `defaultValue: [:]` is accepted silently.
 5. **Unknown keys** are logged at WARN and ignored — stale or mistyped entries in soft config
    surface without breaking startup.
 
@@ -362,12 +364,12 @@ class PricingConfig extends TypedConfigMap {
     PricingConfig(Map args) { init(args) }
 }
 
-// 2. Register it in BootStrap alongside the other config metadata.
+// 2. Register it in BootStrap alongside the other config metadata. No defaultValue - the
+//    class above is the single source of defaults.
 configService.ensureRequiredConfigsCreated([
     new ConfigSpec(
         name: 'pricingSourceConfig',
         valueType: 'json',
-        defaultValue: [endpoint: 'https://prices.example.com', timeoutMs: 5000, fallbackEnabled: true],
         typedClass: PricingConfig,
         groupName: 'Pricing',
         note: '...'

--- a/grails-app/init/io/xh/hoist/BootStrap.groovy
+++ b/grails-app/init/io/xh/hoist/BootStrap.groovy
@@ -103,7 +103,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhActivityTrackingConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: ActivityTrackingConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -112,7 +111,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhAlertBannerConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: AlertBannerConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -145,7 +143,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhChangelogConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: ChangelogConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -154,7 +151,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhClientErrorConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: ClientErrorConfig,
                 groupName: 'xh.io',
                 note: 'Configures handling of client error reports. Errors are queued when received and processed every [intervalMins].'
@@ -162,7 +158,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhConnPoolMonitoringConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: ConnPoolMonitoringConfig,
                 groupName: 'xh.io',
                 note: 'Configures built-in JDBC connection pool monitoring.'
@@ -230,7 +225,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhEntraIdConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: EntraIdConfig,
                 groupName: 'xh.io',
                 note: 'Supports querying Microsoft Entra ID (via Microsoft Graph) for users and groups.'
@@ -259,7 +253,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhEnvPollConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: EnvPollConfig,
                 groupName: 'xh.io',
                 note: "Controls client calls to server to poll for version, instance changes, or auth changes. Supports the following options:\n\n" +
@@ -279,7 +272,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhExportConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: ExportConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -296,7 +288,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhIdleConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: IdleConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -305,7 +296,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhLdapConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: LdapConfig,
                 groupName: 'xh.io',
                 note: 'Supports connecting to LDAP servers.'
@@ -325,7 +315,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhLogArchiveConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: LogArchiveConfig,
                 groupName: 'xh.io',
                 note: 'Configures automatic cleanup and archiving of log files. Files older than "archiveAfterDays" will be moved into zipped bundles within the specified "archiveFolder".'
@@ -333,7 +322,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhMemoryMonitoringConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: MemoryMonitoringConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -342,7 +330,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhMonitorConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: MonitorConfig,
                 groupName: 'xh.io',
                 note: 'Configures server-side status monitoring and notifications. Note failNotifyThreshold and warnNotifyThreshold are the number of refresh cycles a monitor will need to be in said status to trigger "alertMode".'
@@ -357,7 +344,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhMetricsConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: MetricsConfig,
                 groupName: 'xh.io',
                 note: 'Parameters for observable metric support'
@@ -365,7 +351,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhTraceConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: TraceConfig,
                 clientVisible: true,
                 groupName: 'xh.io',
@@ -381,7 +366,6 @@ class BootStrap implements LogSupport {
             new ConfigSpec(
                 name: 'xhWebSocketConfig',
                 valueType: 'json',
-                defaultValue: [:],
                 typedClass: WebSocketConfig,
                 groupName: 'xh.io',
                 note: 'Parameters for the managed WebSocket sessions created by Hoist.'

--- a/grails-app/services/io/xh/hoist/config/ConfigService.groovy
+++ b/grails-app/services/io/xh/hoist/config/ConfigService.groovy
@@ -208,8 +208,9 @@ class ConfigService extends BaseService {
      *  - Server code can load the config via {@link #getObject(Class)}.
      *  - The class's property-initializer defaults are applied at read time for any key missing
      *    from the stored map.
-     *  - Defaults should live solely on the typed class - specs should declare
-     *    `defaultValue: [:]`, and a `WARN` is logged at startup for any that do not.
+     *  - Defaults live solely on the typed class. Omit `defaultValue` from the spec - a missing
+     *    config is seeded with an empty JSON object. An explicit `[:]` is also accepted, but a
+     *    `WARN` is logged at startup for any spec that declares a non-empty default.
      *
      * @param configSpecs - List of {@link ConfigSpec} defining the required configs.
      */
@@ -225,6 +226,9 @@ class ConfigService extends BaseService {
         configSpecs.each { ConfigSpec spec ->
             def currConfig = currConfigs.find { it.name == spec.name },
                 defaultVal = spec.defaultValue
+
+            // Typed configs keep their defaults on the TypedConfigMap subclass - seed an empty object.
+            if (spec.typedClass && defaultVal == null) defaultVal = [:]
 
             if (!currConfig) {
                 if (spec.valueType == 'json') defaultVal = serializePretty(defaultVal)
@@ -347,7 +351,7 @@ class ConfigService extends BaseService {
         if (bootstrapDefault) {
             logWarn(
                 "Config '$confName' declares both a typedClass and a non-empty defaultValue",
-                "defaults should live on ${asTyped.simpleName} - pass defaultValue: [:] in the ConfigSpec"
+                "defaults should live on ${asTyped.simpleName} - omit defaultValue from the ConfigSpec"
             )
         }
     }

--- a/src/main/groovy/io/xh/hoist/config/ConfigSpec.groovy
+++ b/src/main/groovy/io/xh/hoist/config/ConfigSpec.groovy
@@ -22,6 +22,11 @@ import groovy.transform.MapConstructor
 class ConfigSpec {
     String name
     String valueType
+
+    /**
+     * Value seeded when the config does not yet exist. Omit for configs with a {@link #typedClass} -
+     * defaults live on the typed class, and the config is seeded with an empty JSON object.
+     */
     Object defaultValue
     boolean clientVisible = false
     String groupName = 'Default'
@@ -30,6 +35,9 @@ class ConfigSpec {
     /**
      * Optional {@link TypedConfigMap} subclass binding the shape of this config (JSON-type only).
      * Recommended for any structured config with a stable key set — see docs/configuration.md.
+     *
+     * When set, leave {@link #defaultValue} unspecified. The typed class's property initializers
+     * are the defaults, and a non-empty `defaultValue` logs a WARN at startup.
      */
     Class<? extends TypedConfigMap> typedClass
 }


### PR DESCRIPTION
`ConfigService.ensureRequiredConfigsCreated` now seeds a `ConfigSpec` that has a `typedClass` but no `defaultValue` with an empty JSON object, so apps can omit `defaultValue` for typed configs. Defaults live solely on the `TypedConfigMap` subclass. An explicit `defaultValue: [:]` continues to work.

- Drop `defaultValue: [:]` from Hoist's own typed config specs in `BootStrap`
- Update the startup WARN and Groovydoc on `ConfigService` / `ConfigSpec` to recommend omitting `defaultValue`
- Correct `docs/configuration.md` and `docs/coding-conventions.md`, which still showed a full `defaultValue` alongside `typedClass` and described a stale drift-detection behavior
- Add changelog entry under 42.0-SNAPSHOT
