### PR TITLE
Convert EmailService.sendEmail to named parameters, harden address parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@
 
 ## 42.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Hardened address parsing in `EmailService`. A blank entry no longer expands into an invalid
+  address such as `@example.com`, which a blank `xhEmailOverride` config applied to all mail. The
+  service also skips a blank or `none` `xhEmailDefaultDomain`, reads `none` in any letter case, and
+  throws a clear error when no sender address resolves.
+
+### ⚙️ Technical
+
+* `EmailService.sendEmail` now declares its arguments as named parameters. Existing calls need no
+  changes.
+    * ⚠️ A call that passes an unrecognized argument name now fails with an `AssertionError`. The
+      check runs before `sendEmail`, so the `throwError: false` default does not suppress it.
+
 ## 41.0.0 - 2026-08-25
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - most apps require no changes)

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -158,7 +158,8 @@
             "mcpCategory": "package",
             "viewerCategory": "infrastructure",
             "description": "Email sending with config-driven filtering and overrides.",
-            "keywords": ["EmailService", "xhEmailFilter", "xhEmailOverride"]
+            "keywords": ["EmailService", "sendEmail", "parseMailConfig", "xhEmailFilter",
+                "xhEmailOverride", "xhEmailDefaultDomain", "xhEmailDefaultSender", "attachments"]
         },
         {
             "id": "docs/exception-handling.md",

--- a/docs/email.md
+++ b/docs/email.md
@@ -30,9 +30,10 @@ No code changes or redeployments are needed to adjust email routing, filtering, 
 The central service for all outbound email. Application services and the built-in notification
 services (client errors, feedback, monitors) all route through `EmailService.sendEmail()`.
 
-#### `sendEmail(Map args)`
+#### `sendEmail(...)`
 
-The primary method. Accepts a map of arguments:
+The primary method. Arguments are declared as Groovy named parameters (via `@NamedVariant`), so
+they are passed as `key: value` pairs at the call site:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -54,6 +55,23 @@ The primary method. Accepts a map of arguments:
 - `fileName` (`String`) — the file name
 - `contentType` (`String`) — MIME type
 - `contentSource` (`byte[]`, `File`, or `InputStreamSource`) — the content
+
+Because the arguments are declared rather than read from an untyped map, IDEs complete and document
+them inline, and callers compiled with `@CompileStatic` (or `@TypeChecked`) fail to compile on an
+unknown argument name, a wrong argument type, or a missing `to`:
+
+```groovy
+// Compile error under @CompileStatic: [Static type checking] - unexpected named arg: subjekt
+emailService.sendEmail(to: 'jsmith', subjekt: 'Typo', text: 'Hello')
+```
+
+> ⚠️ A dynamically compiled caller gets the same protection at **runtime** instead - an unknown
+> argument name throws an `AssertionError`. That check runs before `sendEmail` itself, so
+> `throwError: false` does not suppress it, and `AssertionError` is an `Error` rather than an
+> `Exception`, so a `catch (Exception)` around the call does not catch it either.
+
+A `Map` may also be passed positionally (`sendEmail(argsMap)`) for callers that build arguments
+dynamically, though no checking is possible in that form.
 
 #### Processing Pipeline
 
@@ -77,11 +95,19 @@ normalized `List<String>`. Used by both `EmailService` itself and the notificati
 (`ClientErrorEmailService`, `FeedbackEmailService`, `MonitorReportService`) to read their recipient
 lists from config.
 
+An empty or blank config yields an empty list. (Blank entries are never expanded into a bare
+`@domain` address - see `parseAddresses` below.)
+
 #### `parseAddresses(String s)`
 
 Parses a comma-delimited string of email addresses into a normalized list. Returns `null` for the
-special string `"none"`, which allows configs to explicitly disable email by setting their value to
-`none`.
+special string `"none"` (case-insensitive), which allows configs to explicitly disable email by
+setting their value to `none`.
+
+Blank and whitespace-only entries are discarded before the `xhEmailDefaultDomain` config is
+applied, so `''`, `'  '`, and `'a@b.com,,'` never produce a bare `@example.com` recipient. If
+`xhEmailDefaultDomain` is itself blank or `none`, unqualified addresses are left as-is, with no
+bare `@` suffix.
 
 #### Admin Stats
 

--- a/grails-app/services/io/xh/hoist/email/EmailService.groovy
+++ b/grails-app/services/io/xh/hoist/email/EmailService.groovy
@@ -6,10 +6,15 @@
  */
 package io.xh.hoist.email
 
+import grails.plugins.mail.MailMessageBuilder
+import groovy.transform.CompileStatic
+import groovy.transform.NamedParam
+import groovy.transform.NamedVariant
 import io.xh.hoist.BaseService
 import io.xh.hoist.config.AppConfig
+import io.xh.hoist.config.ConfigService
 import io.xh.hoist.util.Utils
-
+import org.springframework.core.io.InputStreamSource
 
 /**
  * Service for sending email, controlled and managed via several soft configuration options for flexibility and safer
@@ -19,63 +24,88 @@ import io.xh.hoist.util.Utils
  *  + xhEmailFilter - addresses to which the service is allowed to send mail (or "none" for no filtering).
  *  + xhEmailOverride - addresses to which the service will send all mail, regardless of sendEmail() args (or "none").
  */
+@CompileStatic
 class EmailService extends BaseService {
 
-    def configService
+    ConfigService configService
 
     private Date lastSentDate = null
-    private Long emailsSent = 0
+    private long emailsSent = 0
 
     /**
-     * Send email as specified by args param.
-     * Application environment will be appended to subject unless environment is Production.
+     * Send an email, with recipients, content, and delivery options given as named arguments.
      *
-     * @param args
-     *      to {String or List}     - required, email address(es) of recipient(s)
-     *      from {String}           - optional, sender address, defaults to config
-     *      cc {String or List}     - optional, cc recipients
-     *      bcc {String or List}    - optional, bcc recipients
-     *      subject {String}        - optional
-     *      markImportant {boolean} - optional, to mark email as important via standard headers, default false
-     *      async {Boolean}         - option to send email asynchronously, defaults to false
-     *      doLog {Boolean}         - option to log email information on send, defaults to true
-     *      logIdentifier {String}  - optional, string to append to log message, defaults to subject
-     *      throwError {Boolean}    - option to throw on error or to suppress and log, defaults to false
+     * Requires a `to` address, plus one of `html` or `text` for the body. All recipients are
+     * subject to the `xhEmailFilter` and `xhEmailOverride` configs, and the application
+     * environment is appended to the subject unless running in Production.
      *
-     * To determine email body, either "text" OR "html" must be included in args:
+     * See `docs/email.md` for configuration details and examples.
      *
-     *      text {String}           - plain text message
-     *      html {String}           - html message
-     *
-     * To attach file(s) to the email, include:
-     *
-     *      attachments {Map or List<Map>}
-     *             fileName {String}
-     *             contentType {String}
-     *             contentSource {byte[] or File or InputStreamSource}
+     * @param to             address(es) of recipient(s), as a String (comma-delimited) or
+     *                       {@code List<String>}
+     * @param cc             address(es) to copy, in the same forms accepted by `to`
+     * @param bcc            address(es) to blind copy, in the same forms accepted by `to`
+     * @param from           sender address, defaulting to the `xhEmailDefaultSender` config
+     * @param subject        subject line, truncated to 255 chars after any environment context
+     *                       has been appended
+     * @param html           HTML message body. Provide either this or `text`.
+     * @param text           plain-text message body. Provide either this or `html`.
+     * @param attachments    file attachment(s), as a single Map or {@code List<Map>}. Each Map
+     *                       requires `fileName` and `contentType` Strings, plus a `contentSource`
+     *                       of byte[], File, or InputStreamSource.
+     * @param markImportant  true to mark the email as important via standard headers
+     * @param async          true to send asynchronously, without blocking on the SMTP round-trip
+     * @param doLog          false to suppress the info-level message logged on a successful send
+     * @param logIdentifier  identifier to log in place of the subject, defaulting to `subject`
+     * @param throwError     true to rethrow any send failure. Default false to log and suppress.
      */
-    void sendEmail(Map args) {
-        def logMsg = "",
-            throwError = args.throwError
+    @NamedVariant
+    void sendEmail(
+
+        // Recipients and sender
+        @NamedParam(required = true) Object to,
+        @NamedParam Object cc = null,
+        @NamedParam Object bcc = null,
+        @NamedParam String from = null,
+
+        // Content - one of `html` or `text` is required
+        @NamedParam String subject = null,
+        @NamedParam String html = null,
+        @NamedParam String text = null,
+        @NamedParam Object attachments = null,
+
+        // Delivery and logging options
+        @NamedParam boolean markImportant = false,
+        @NamedParam boolean async = false,
+        @NamedParam boolean doLog = true,
+        @NamedParam String logIdentifier = null,
+        @NamedParam boolean throwError = false
+    ) {
+        Map logMsg = [:]
 
         try {
             // 1) Pre-process and normalize inputs and configs
-            def override = parseMailConfig('xhEmailOverride'),
+            List<String> override = parseMailConfig('xhEmailOverride'),
                 filter = parseMailConfig('xhEmailFilter'),
-                toSpec = filterAddresses(formatAddresses(args.to), filter),
-                ccSpec = filterAddresses(formatAddresses(args.cc), filter),
-                bccSpec = filterAddresses(formatAddresses(args.bcc), filter)
+                toSpec = filterAddresses(formatAddresses(to), filter),
+                ccSpec = filterAddresses(formatAddresses(cc), filter),
+                bccSpec = filterAddresses(formatAddresses(bcc), filter)
 
-            List<String> toUse = override ? override : toSpec
+            List<String> toUse = override ?: toSpec
             List<String> ccUse = override ? [] : ccSpec
             List<String> bccUse = override ? [] : bccSpec
-            String fromUse = args.from ? formatAddresses(args.from)[0] : parseMailConfig('xhEmailDefaultSender')[0]
-            String subjectUse = args.subject ?: ''
-            List<Map> attachments = parseAttachments(args.attachments)
-            boolean hasAttachments = args.attachments as boolean
-            boolean doLog = args.containsKey('doLog') ? args.doLog : true
 
-            logMsg = createLogMsg(args, fromUse, filter, override)
+            List<String> fromSpec = from ? formatAddresses(from) : parseMailConfig('xhEmailDefaultSender')
+            String fromUse = fromSpec ? fromSpec.first() : null
+            if (!fromUse) {
+                throw new RuntimeException("Must provide a 'from' address, or a valid xhEmailDefaultSender config.")
+            }
+
+            String subjectUse = subject ?: ''
+            List<Map> attachmentsUse = parseAttachments(attachments)
+            boolean hasAttachments = attachmentsUse as boolean
+
+            logMsg = createLogMsg(logIdentifier, subject, to, fromUse, filter, override)
 
             // 2) Early outs
             if (Utils.isLocalDevelopment && !override && !filter) {
@@ -92,12 +122,12 @@ class EmailService extends BaseService {
             }
 
             // 3) Enhance subject with context
-            def devContext = []
+            List<String> devContext = []
             if (!Utils.isProduction) {
-                devContext << Utils.appEnvironment.displayName.toUpperCase();
+                devContext << Utils.appEnvironment.displayName.toUpperCase()
             }
             if (override) {
-                devContext << (toSpec.size() > 1 ? "for ${toSpec.size()} recipients" : "for ${toSpec.first()}")
+                devContext << (toSpec.size() > 1 ? "for ${toSpec.size()} recipients" : "for ${toSpec.first()}").toString()
             }
             if (devContext) {
                 subjectUse += " [${devContext.join(', ')}]"
@@ -105,36 +135,52 @@ class EmailService extends BaseService {
 
             // 4) Send email!
             sendMail {
-                multipart hasAttachments
-                async(args.async as boolean)
-                from fromUse
-                to toUse.toArray()
+                // Builder bound explicitly - named params above shadow its same-named DSL methods.
+                MailMessageBuilder msg = delegate as MailMessageBuilder
+
+                msg.multipart hasAttachments
+                msg.async async
+                msg.from fromUse
+                msg.to toUse
                 if (ccUse) {
-                    cc ccUse.toArray()
+                    msg.cc ccUse
                 }
                 if (bccUse) {
-                    bcc bccUse.toArray()
+                    msg.bcc bccUse
                 }
-                if (args.markImportant) {
-                    headers (
+                if (markImportant) {
+                    msg.headers (
                         'Importance': 'High',
                         'X-MSMail-Priority': 'High',
                         'X-Priority': 1
                     )
                 }
 
-                subject subjectUse.take(255)
+                msg.subject subjectUse.take(255)
 
-                if (args.containsKey('html')) {
-                    html args.html as String
-                } else if (args.containsKey('text')) {
-                    text args.text as String
+                if (html != null) {
+                    msg.html html
+                } else if (text != null) {
+                    msg.text text
                 } else {
                     throw new RuntimeException("Must provide 'html' or 'text' for email.")
                 }
 
-                attachments.each { Map f ->
-                    attach f.fileName as String, f.contentType as String, f.contentSource
+                for (Map f : attachmentsUse) {
+                    String fileName = f.fileName as String,
+                        contentType = f.contentType as String
+                    Object src = f.contentSource
+                    if (src instanceof byte[]) {
+                        msg.attach fileName, contentType, (byte[]) src
+                    } else if (src instanceof File) {
+                        msg.attach fileName, contentType, (File) src
+                    } else if (src instanceof InputStreamSource) {
+                        msg.attach fileName, contentType, (InputStreamSource) src
+                    } else {
+                        throw new RuntimeException(
+                            "Attachment '$fileName' must provide a contentSource of byte[], File, or InputStreamSource."
+                        )
+                    }
                 }
             }
             emailsSent++
@@ -154,19 +200,21 @@ class EmailService extends BaseService {
      * Read a set of email addresses from an app config, normalizing as per {@link #parseAddresses}.
      */
     List<String> parseMailConfig(String configName) {
-        def addresses = configService.getStringList(configName)
-        return parseAddresses(addresses.join(','))
+        return parseAddresses(configService.getStringList(configName).join(','))
     }
 
     /**
      *  Parse a comma delimited list of email addresses into a list of trimmed, properly
      *  formatted addresses, appending the xhEmailDefaultDomain config to any unqualified address.
      *
+     *  Blank/whitespace-only entries are discarded - an empty or blank input yields an empty list,
+     *  never a bare "@domain" address.
+     *
      *  Includes special support for returning null if given {@link AppConfig#NONE}, to allow for
      *  sourcing optional / potentially-empty addresses from string configs.
      */
     List<String> parseAddresses(String s) {
-        return s == AppConfig.NONE ? null : formatAddresses(s)
+        return s?.trim()?.equalsIgnoreCase(AppConfig.NONE) ? null : formatAddresses(s)
     }
 
     Map getAdminStats() {
@@ -186,33 +234,50 @@ class EmailService extends BaseService {
     // Implementation
     //------------------------
     private List<String> filterAddresses(Collection<String> rawEmails, List<String> filter) {
-        filter ? filter.intersect(rawEmails) : rawEmails
+        filter ? (List<String>) filter.intersect(rawEmails) : rawEmails.toList()
     }
 
+    /**
+     * Normalize a String (comma-delimited) or Collection of addresses into a list of trimmed,
+     * fully-qualified addresses. Blank entries are dropped, and the xhEmailDefaultDomain config is
+     * appended to any unqualified address (skipped if that config is itself unset or "none").
+     */
     private List<String> formatAddresses(Object o) {
-        if (o instanceof String) o = o.split(',')
         if (!o) return []
 
-        String defaultDomain = configService.getString('xhEmailDefaultDomain')
+        List<String> raw = o instanceof CharSequence ?
+            o.toString().tokenize(',') :
+            (o as Collection<?>).collect { it?.toString() }
+
+        List<String> ret = raw.collect { it?.trim() }.findAll { it } as List<String>
+        if (!ret) return []
+
+        String defaultDomain = configService.getString('xhEmailDefaultDomain')?.trim()
+        if (!defaultDomain || defaultDomain.equalsIgnoreCase(AppConfig.NONE)) return ret
         if (!defaultDomain.startsWith('@')) defaultDomain = '@' + defaultDomain
 
-        return o.collect { String email ->
-            email = email.trim()
-            email.contains('@') ? email : (email + defaultDomain)
-        }
+        return ret.collect { it.contains('@') ? it : it + defaultDomain }
     }
 
     private List<Map> parseAttachments(Object attachments) {
-        attachments ? (attachments instanceof Map ? [attachments] : attachments) : []
+        if (!attachments) return []
+        return attachments instanceof Map ? [attachments as Map] : (attachments as List<Map>)
     }
 
-    private Map createLogMsg(Map args, String fromUse, List<String> filters, List<String> override) {
-        String logIdentifier = args.logIdentifier ?: args.subject ?: '[No Subject]'
-        def ret = [
-            _id : logIdentifier.take(70),
+    private Map createLogMsg(
+        String logIdentifier,
+        String subject,
+        Object to,
+        String fromUse,
+        List<String> filters,
+        List<String> override
+    ) {
+        Map<String, Object> ret = [
+            _id : (logIdentifier ?: subject ?: '[No Subject]').take(70),
             from: fromUse,
-            to  : args.to?.toString()?.take(255)
-        ]
+            to  : to?.toString()?.take(255)
+        ] as Map<String, Object>
+
         if (override) {
             ret.redirectedTo = override
         } else if (filters) {
@@ -222,4 +287,3 @@ class EmailService extends BaseService {
         return ret
     }
 }
-


### PR DESCRIPTION
Converts `EmailService.sendEmail` to Groovy named parameters and fixes a set of address-parsing bugs found along the way.

### Named parameters

- `sendEmail` now declares its 13 arguments via `@NamedVariant` / `@NamedParam`, documented with `@param` Groovydoc.
- **No call-site changes required.** The generated `sendEmail(Map)` variant still accepts named args, a map literal, and a map held in a variable. All existing callers in hoist-core and Toolbox pass only valid keys.
- `@CompileStatic` callers now get compile-time errors for an unknown argument name, a wrong argument type, or a missing `to`. Dynamic callers get the same checks at runtime.
- ⚠️ An unrecognized argument name now throws, where it was previously ignored. The check runs before `sendEmail`, so `throwError: false` does not suppress it, and `AssertionError` is an `Error`, so `catch (Exception)` around the call will not catch it.

### Address-parsing fixes

- Blank entries are discarded, so a blank config no longer expands into an invalid address such as `@example.com`. A blank `xhEmailOverride` was the worst case - that address is truthy, so it redirected all mail to it.
- The `xhEmailDefaultDomain` suffix is skipped when that config is itself blank or `none`, rather than appending a bare `@`.
- `parseAddresses` reads `none` in any letter case.
- `sendEmail` throws a clear error when it cannot resolve a sender address.

### Also

- `EmailService` is now `@CompileStatic`. This required binding the mail builder explicitly inside the `sendMail` closure, because the named parameters shadow its same-named DSL methods, and dispatching `attach` on the `contentSource` type.
- `docs/email.md` and the CHANGELOG updated.

Related: #600 tracks the MCP symbol tools dropping per-argument documentation, which is why the `@param` tags here are not yet visible to agents.
