### PR TITLE
Route all directory group operations through getDirectoryService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@
 
 ## 42.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟠 Minor)
+
+See [`docs/upgrade-notes/v42-upgrade-notes.md`](docs/upgrade-notes/v42-upgrade-notes.md) for
+detailed, step-by-step upgrade instructions with before and after code examples.
+
+* Removed `DefaultRoleService.doLoadUsersForDirectoryGroups`. Apps that resolve directory groups
+  from a custom source now override `getDirectoryService` to return their own `DirectoryService`
+  implementation. Apps that do not override the removed method require no changes.
+
+### 🐞 Bug Fixes
+
+* `DefaultRoleService.describeDirectoryGroups` and `searchDirectoryGroups` now resolve through the
+  overridable `getDirectoryService`, so an app with a custom directory group source no longer sees
+  "No enabled directory service in this application" reported for every group by the
+  `roleAdmin/directoryGroupsInfo` endpoint, or an empty group search in the Admin Console.
+
 ### ⚙️ Technical
 
 * `ConfigService.ensureRequiredConfigsCreated` now seeds a `ConfigSpec` that has a `typedClass` but

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -213,9 +213,9 @@ ensureRequiredRolesCreated([
 ])
 ```
 
-Override `doLoadUsersForDirectoryGroups()` to resolve groups from different, or additional,
-external sources. Return a `Map` of group identifier to an `ErrorOr` that holds either the
-`Set` of member usernames or a String error description.
+Applications with a different external source can override `getDirectoryService()` to return
+their own implementation of the narrow `DirectoryService` interface. That single override backs
+membership resolution, Admin Console display names, and group search alike.
 
 #### Customization Points
 
@@ -226,7 +226,7 @@ external sources. Return a `Map` of group identifier to an `ErrorOr` that holds 
 | `getUserAssignmentSupported()` | `true` | Set to `false` to disable direct user-to-role assignment |
 | `getDirectoryGroupsSupported()` | `true` | Set to `false` to disable directory group membership |
 | `getDirectoryGroupsDescription()` | From the selected `DirectoryService` | Short string for Admin Console tooltip |
-| `doLoadUsersForDirectoryGroups()` | Selected `DirectoryService` | Override to resolve groups from other sources |
+| `getDirectoryService()` | `LdapService` or `EntraIdService`, per `directoryGroupProvider` | Override to resolve groups from another source |
 
 #### Configuration
 

--- a/docs/directory-services.md
+++ b/docs/directory-services.md
@@ -86,7 +86,7 @@ its role memberships to the new source. Set `directoryGroupProvider` explicitly 
 the conflict.
 
 Applications with a different external source can override
-`DefaultRoleService.doLoadUsersForDirectoryGroups()` - see
+`DefaultRoleService.getDirectoryService()` to return their own `DirectoryService` - see
 [`authorization.md`](./authorization.md#directory-group-integration).
 
 ### Group Identifiers

--- a/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
+++ b/src/main/groovy/io/xh/hoist/role/provided/DefaultRoleService.groovy
@@ -35,9 +35,8 @@ import static java.util.Collections.*
  * <p>Applications that opt in to this default implementation must either:
  * <ol>
  *   <li>Define a `RoleService` class that extends this class. The app can then override its
- *       protected methods to customize behavior, including
- *       {@link #doLoadUsersForDirectoryGroups} to resolve external directory group memberships
- *       (see below).</li>
+ *       protected methods to customize behavior, including {@link #getDirectoryService} to
+ *       resolve external directory group memberships (see below).</li>
  *   <li>Register this class directly as `roleService` via
  *       `grails-app/conf/spring/resources.groovy`, if no customizations are required.</li>
  * </ol>
@@ -60,10 +59,10 @@ import static java.util.Collections.*
  * those groups then inherit membership in the role. Roles themselves are still created and
  * managed in the local app database via the Admin Console. The default implementation resolves
  * groups via an enabled {@link DirectoryService} implementation - {@link LdapService} or
- * {@link EntraIdService} - see {@link #getDirectoryService} for selection details. Override
- * {@link #doLoadUsersForDirectoryGroups} to resolve groups from different or additional external
- * sources. If that method throws, this service logs an error and continues to use the result of
- * the last successful lookup. A call to {@link #clearCaches} also clears that cached lookup.
+ * {@link EntraIdService} - see {@link #getDirectoryService} for selection details. Override that
+ * method to supply a custom {@link DirectoryService} and resolve groups from a different source.
+ * If group resolution throws, this service logs an error and continues to use the result of the
+ * last successful lookup. A call to {@link #clearCaches} also clears that cached lookup.
  *
  * <p>This service and its Admin Console UI are configurable via a JSON `xhRoleModuleConfig`
  * soft-config, created by this service on startup if not found. Supported keys:
@@ -190,54 +189,20 @@ class DefaultRoleService extends BaseRoleService {
     }
 
     /**
-     * Resolve directory group identifiers to their member users.
+     * Resolve directory group identifiers to their member users, delegating to the selected
+     * {@link DirectoryService} - see {@link #getDirectoryService}.
      *
-     * <p>The default implementation delegates to the selected {@link DirectoryService}
-     * implementation - see {@link #getDirectoryService}. Override this method to resolve groups
-     * from different, or additional, external sources.
-     *
-     * <p>If strictMode is true, implementations must throw on any partial failure. Otherwise
-     * they log the failure and return whatever groups they can load.
-     *
-     * <p>If no directory service is enabled, the default implementation returns an error
-     * description for every group rather than throwing, keeping role resolution and the Admin
-     * Console UI functional (with inline warnings) in a misconfigured app.
+     * <p>If strictMode is true, the lookup throws on any partial failure. Otherwise it logs the
+     * failure and returns whatever groups it can load.
      *
      * @return Map of directory group identifier to an {@link ErrorOr} holding either the Set of
      *         assigned usernames (on success) or a description of the lookup error (on failure).
      */
-    protected Map<String, ErrorOr<Set<String>>> doLoadUsersForDirectoryGroups(Set<String> groups, boolean strictMode) {
+    Map<String, ErrorOr<Set<String>>> loadUsersForDirectoryGroups(Set<String> groups, boolean strictMode) {
         def svc = directoryService
         if (!groups) return emptyMap()
         if (!svc.enabled) return notEnabledResult(groups)
         svc.loadUsersForDirectoryGroups(groups, strictMode)
-    }
-
-    /**
-     * The {@link DirectoryService} implementation used to resolve directory groups and back
-     * related Admin Console UI features.
-     *
-     * <p>Selected via the optional `directoryGroupProvider` key in `xhRoleModuleConfig` -
-     * `'ldap'`, `'entraId'`, or the default `'auto'`, which resolves to whichever single
-     * implementation is enabled. When both are enabled under auto, this method logs an ERROR
-     * and returns the LDAP implementation, so that an app experimenting with Entra ID does not
-     * silently switch its role memberships to the new source.
-     */
-    protected DirectoryService getDirectoryService() {
-        String provider = config.directoryGroupProvider ?: 'auto'
-        switch (provider) {
-            case 'ldap': return ldapService
-            case 'entraId': return entraIdService
-            case 'auto': break
-            default:
-                logError("Unknown xhRoleModuleConfig.directoryGroupProvider '$provider'", "expected 'ldap', 'entraId', or 'auto'", 'falling back to auto selection')
-        }
-
-        if (ldapService.enabled && entraIdService.enabled) {
-            logError('Both LdapService and EntraIdService are enabled', "set xhRoleModuleConfig.directoryGroupProvider to select one", 'using LdapService')
-            return ldapService
-        }
-        return entraIdService.enabled ? entraIdService : ldapService
     }
 
     /**
@@ -259,6 +224,36 @@ class DefaultRoleService extends BaseRoleService {
     List<Map> searchDirectoryGroups(String namePart) {
         def svc = directoryService
         (namePart && svc.enabled) ? svc.searchDirectoryGroups(namePart) : []
+    }
+
+    /**
+     * The {@link DirectoryService} implementation used to resolve directory groups and back
+     * related Admin Console UI features.
+     *
+     * <p>Selected via the optional `directoryGroupProvider` key in `xhRoleModuleConfig` -
+     * `'ldap'`, `'entraId'`, or the default `'auto'`, which resolves to whichever single
+     * implementation is enabled. When both are enabled under auto, this method logs an ERROR
+     * and returns the LDAP implementation, so that an app experimenting with Entra ID does not
+     * silently switch its role memberships to the new source.
+     *
+     * <p>Override to resolve groups from a source other than LDAP or Entra ID, returning a
+     * custom implementation of the {@link DirectoryService} interface.
+     */
+    protected DirectoryService getDirectoryService() {
+        String provider = config.directoryGroupProvider ?: 'auto'
+        switch (provider) {
+            case 'ldap': return ldapService
+            case 'entraId': return entraIdService
+            case 'auto': break
+            default:
+                logError("Unknown xhRoleModuleConfig.directoryGroupProvider '$provider'", "expected 'ldap', 'entraId', or 'auto'", 'falling back to auto selection')
+        }
+
+        if (ldapService.enabled && entraIdService.enabled) {
+            logError('Both LdapService and EntraIdService are enabled', "set xhRoleModuleConfig.directoryGroupProvider to select one", 'using LdapService')
+            return ldapService
+        }
+        return entraIdService.enabled ? entraIdService : ldapService
     }
 
     /**
@@ -343,11 +338,6 @@ class DefaultRoleService extends BaseRoleService {
     //---------------------------
     // Implementation/Framework
     //---------------------------
-    /** Framework entry point for directory group resolution - apps override {@link #doLoadUsersForDirectoryGroups}. */
-    final Map<String, ErrorOr<Set<String>>> loadUsersForDirectoryGroups(Set<String> directoryGroups, boolean strictMode) {
-        doLoadUsersForDirectoryGroups(directoryGroups, strictMode)
-    }
-
     /**
      * Per-group error results for when no enabled {@link DirectoryService} is available.
      * DirectoryService methods throw when called while not enabled - this service instead


### PR DESCRIPTION
`roleAdmin/directoryGroupsInfo` reported `No enabled directory service in this application` for every assigned group in any app that resolves directory groups from its own source (Toolbox, via its mock, is the case in hand). `DefaultRoleService.describeDirectoryGroups` and `searchDirectoryGroups` went straight to the selected `DirectoryService`, while only membership resolution had an app-level hook - `doLoadUsersForDirectoryGroups`. That asymmetry was the bug.

`DirectoryService` is already the narrow contract for exactly these operations, and `getDirectoryService()` is already protected, so the fix removes a seam rather than adding two.

Key changes:

- Removed `DefaultRoleService.doLoadUsersForDirectoryGroups` and the `final loadUsersForDirectoryGroups` wrapper that only called it. `loadUsersForDirectoryGroups` is now a plain public method with that same body, symmetric with the other two.
- Documented `getDirectoryService()` as the single override seam for group resolution, display names, and group search alike.
- Updated `docs/authorization.md` and `docs/directory-services.md` to point at the new seam.
- Changelog: a Breaking Changes bullet for the removal, plus a Bug Fixes bullet for the bogus errors.

Toolbox companion PR replaces its `doLoadUsersForDirectoryGroups` override with a `MockDirectoryService`: https://github.com/xh/toolbox/pull/902

Two notes for review:

- I opened the `42.0-SNAPSHOT` Breaking Changes section and rated it `MEDIUM - Grails 8 / Groovy 5` to match the in-flight v42 upgrade notes. The Grails 8 bullets themselves are not in the changelog yet.
- `docs/upgrade-notes/v42-upgrade-notes.md` is deliberately not part of this PR - the v42 notes get generated when the time is right. The changelog's link to that file therefore dangles until they land, and the upgrade step for this change ("Replace a `doLoadUsersForDirectoryGroups` override") goes in then.

